### PR TITLE
Fix _doing_it_wrong Notice since WP 5.5

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -70,6 +70,7 @@ class Auth {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_token' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 
@@ -79,6 +80,7 @@ class Auth {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'validate_token' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 	}


### PR DESCRIPTION
Since WP 5.5, WP requires the permission_callback argument (see https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/)