### PR TITLE
Added refresh token architecture.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ package-lock.json
 
 vendor/
 composer.lock
+
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -756,6 +756,23 @@ add_filter(
 ```
 
 
+## Automated Tests
+
+There are end-to-end tests you can run to confirm that the API works correctly:
+
+```console
+$ URL=https://example.local USERNAME=myuser PASSWORD=mypass composer run test
+> ./vendor/bin/phpunit
+PHPUnit 9.5.13 by Sebastian Bergmann and contributors.
+
+.............                                                     13 / 13 (100%)
+
+Time: 00:12.377, Memory: 6.00 MB
+
+OK (13 tests, 110 assertions)
+```
+
+
 ## Credits
 
 - [PHP-JWT from firebase](https://github.com/firebase/php-jwt)

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ If the token is invalid an error will be returned. Here are some samples of erro
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 500,
 	"code": "jwt_auth_bad_config",
 	"message": "JWT is not configured properly.",
 	"data": []
@@ -259,7 +259,7 @@ If the token is invalid an error will be returned. Here are some samples of erro
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 401,
 	"code": "jwt_auth_no_auth_header",
 	"message": "Authorization header not found.",
 	"data": []
@@ -271,7 +271,7 @@ If the token is invalid an error will be returned. Here are some samples of erro
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 401,
 	"code": "jwt_auth_bad_iss",
 	"message": "The iss do not match with this server.",
 	"data": []
@@ -283,19 +283,19 @@ If the token is invalid an error will be returned. Here are some samples of erro
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 401,
 	"code": "jwt_auth_invalid_token",
 	"message": "Signature verification failed",
 	"data": []
 }
 ```
 
-**Bad Request**
+**Incomplete Payload**
 
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 401,
 	"code": "jwt_auth_bad_request",
 	"message": "User ID not found in the token.",
 	"data": []
@@ -307,7 +307,7 @@ If the token is invalid an error will be returned. Here are some samples of erro
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 401,
 	"code": "jwt_auth_user_not_found",
 	"message": "User doesn't exist",
 	"data": []
@@ -319,7 +319,7 @@ If the token is invalid an error will be returned. Here are some samples of erro
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 401,
 	"code": "jwt_auth_invalid_token",
 	"message": "Expired token",
 	"data": []
@@ -331,7 +331,7 @@ If the token is invalid an error will be returned. Here are some samples of erro
 ```json
 {
 	"success": false,
-	"statusCode": 403,
+	"statusCode": 401,
 	"code": "jwt_auth_obsolete_token",
 	"message": "Token is obsolete",
 	"data": []

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ The `jwt_auth_expire` allows you to change the [**exp**](https://tools.ietf.org/
 Default Value:
 
 ```
-time() + HOUR_IN_SECONDS
+time() + (MINUTE_IN_SECONDS * 10)
 ```
 
 Usage example:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can use the optional parameter `device` with the device identifier to let us
 		"firstName": "Bagus Javas",
 		"lastName": "Heruyanto",
 		"displayName": "contactjavas",
-		"refreshToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvc2VydmljZS50ZXN0LmJubi5kZSIsImlhdCI6MTYyNDQ1NzA2MSwibmJmIjoxNjI0NDU3MDYxLCJleHAiOjE2MjcwNDkwNjEsImRhdGEiOnsidXNlciI6eyJpZCI6NTA1NjUsImRldmljZSI6IiIsInBhc3MiOiJkZGU1YThlM2ZmYjQ2ZTBiNzY4OWI5M2QwNzk0MTk5OCJ9fX0.UNlvDB2p601BNXDa-OBtt5jnXjttx0bL7VhHDyud8-E"
+		"refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvc2VydmljZS50ZXN0LmJubi5kZSIsImlhdCI6MTYyNDQ1NzA2MSwibmJmIjoxNjI0NDU3MDYxLCJleHAiOjE2MjcwNDkwNjEsImRhdGEiOnsidXNlciI6eyJpZCI6NTA1NjUsImRldmljZSI6IiIsInBhc3MiOiJkZGU1YThlM2ZmYjQ2ZTBiNzY4OWI5M2QwNzk0MTk5OCJ9fX0.UNlvDB2p601BNXDa-OBtt5jnXjttx0bL7VhHDyud8-E"
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ add_filter(
 
 ### jwt_auth_refresh_expire
 
-The `jwt_auth_refresh_expire` filter hook allows you to change the [**exp**](https://tools.ietf.org/html/rfc7519#section-4.1.4) value before the payload of the refresh token is encoded.
+The `jwt_auth_refresh_expire` filter hook allows you to change the expiration date of the refresh token.
 
 Default Value:
 

--- a/README.md
+++ b/README.md
@@ -543,12 +543,12 @@ Usage example:
 
 ```php
 /**
- * Change the refresh token's expire value.
+ * Change the refresh token's expiration time.
  *
- * @param int $expire The default "exp" value in timestamp.
- * @param int $issued_at The "iat" value in timestamp.
+ * @param int $expire The default expiration timestamp.
+ * @param int $issued_at The current time.
  *
- * @return int The "nbf" value.
+ * @return int The custom refresh token expiration timestamp.
  */
 add_filter(
 	'jwt_auth_refresh_expire',

--- a/README.md
+++ b/README.md
@@ -496,39 +496,6 @@ add_filter(
 );
 ```
 
-### jwt_auth_refresh_not_before
-
-The `jwt_auth_refresh_not_before` filter hook allows you to change the [**nbf**](https://tools.ietf.org/html/rfc7519#section-4.1.5) value before the payload of the refresh token is encoded.
-
-Default Value:
-
-```
-// Creation time.
-time()
-```
-
-Usage example:
-
-```php
-/**
- * Change the refresh token's nbf value.
- *
- * @param int $not_before The default "nbf" value in timestamp.
- * @param int $issued_at The "iat" value in timestamp.
- *
- * @return int The "nbf" value.
- */
-add_filter(
-	'jwt_auth_refresh_not_before',
-	function ( $not_before, $issued_at ) {
-		// Modify the "not_before" here.
-		return $not_before;
-	},
-	10,
-	2
-);
-```
-
 ### jwt_auth_refresh_expire
 
 The `jwt_auth_refresh_expire` filter hook allows you to change the [**exp**](https://tools.ietf.org/html/rfc7519#section-4.1.4) value before the payload of the refresh token is encoded.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ You can use the optional parameter `device` with the device identifier to let us
 		"nicename": "contactjavas",
 		"firstName": "Bagus Javas",
 		"lastName": "Heruyanto",
-		"displayName": "contactjavas",
-		"refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvc2VydmljZS50ZXN0LmJubi5kZSIsImlhdCI6MTYyNDQ1NzA2MSwibmJmIjoxNjI0NDU3MDYxLCJleHAiOjE2MjcwNDkwNjEsImRhdGEiOnsidXNlciI6eyJpZCI6NTA1NjUsImRldmljZSI6IiIsInBhc3MiOiJkZGU1YThlM2ZmYjQ2ZTBiNzY4OWI5M2QwNzk0MTk5OCJ9fX0.UNlvDB2p601BNXDa-OBtt5jnXjttx0bL7VhHDyud8-E"
+		"displayName": "contactjavas"
 	}
 }
 ```
@@ -231,11 +230,45 @@ But if you want to test or validate the token manually, then send a **POST** req
 
 For security reasons, third-party applications that are integrating with your authentication server will not store the user's username and password. Instead they will store the refresh token in a user-specific storage that is only accessible for the user. The refresh token can be used to re-authenticate as the same user and generate a new access token.
 
-To generate a new access token, send the refresh token in the HTTP **POST** header _Authorization: Bearer_:
+When authenticating with `username` and `password` as the parameters to `/wp-json/jwt-auth/v1/token`, a refresh token is sent as a cookie in the response.
+
+`/wp-json/jwt-auth/v1/token`
+
+To generate new access token using the refresh token, submit a POST request to the token endpoint together with the `refresh_token` cookie.
+
+Use the optional parameter `device` with the device identifier to associate the token with that device.
+
+If the refresh token is valid, then you receive a new access token in the response.
+
+By default, each access token expires after 10 minutes.
+
 
 `/wp-json/jwt-auth/v1/token/refresh`
 
-The response is the same as for the `/token` response - only without a new `refreshToken`.
+To generate new refresh token using the refresh token, submit a POST request to the token refresh endpoint together with the `refresh_token` cookie.
+
+Use the optional parameter `device` with the device identifier to associate the refresh token with that device.
+
+If the refresh token is valid, then you receive a new refresh token as a cookie in the response.
+
+By default, each refresh token expires after 30 days.
+
+
+### Refresh Token Rotation
+
+Whenever you are authenticating afresh or refreshing the refresh token, only the last issued refresh token remains valid. All previously issued refresh tokens can no longer be used.
+
+This means that a refresh token cannot be shared. To allow multiple devices to authenticate in parallel without losing access after another device re-authenticated, use the parameter `device` with the device identifier to associate the refresh token only with that device.
+
+```sh
+curl -F device="abc-def" -F username=myuser -F password=mypass /wp-json/jwt-auth/v1/token
+```
+```sh
+curl -F device="abc-def" -b "refresh_token=123.abcdef..." /wp-json/jwt-auth/v1/token
+```
+```sh
+curl -F device="abc-def" -b "refresh_token=123.abcdef..." /wp-json/jwt-auth/v1/token/refresh
+```
 
 
 ## Error Responses

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ When the plugin is activated, a new namespace is added.
 /jwt-auth/v1
 ```
 
-Also, two new endpoints are added to this namespace.
+Also, three new endpoints are added to this namespace.
 
 | Endpoint                              | HTTP Verb |
 | ------------------------------------- | --------- |

--- a/class-auth.php
+++ b/class-auth.php
@@ -215,7 +215,7 @@ class Auth {
 		$issued_at  = time();
 		$not_before = $issued_at;
 		$not_before = apply_filters( 'jwt_auth_not_before', $not_before, $issued_at );
-		$expire     = $issued_at + (MINUTE_IN_SECONDS * 10);
+		$expire     = $issued_at + ( MINUTE_IN_SECONDS * 10 );
 		$expire     = apply_filters( 'jwt_auth_expire', $expire, $issued_at );
 
 		return $this->do_generate_token( $issued_at, $not_before, $expire, $user, $return_raw );

--- a/class-auth.php
+++ b/class-auth.php
@@ -317,6 +317,7 @@ class Auth {
 			$user_refresh_tokens = array();
 		}
 		$device = isset( $_POST['device'] ) ? $_POST['device'] : '';
+		// @todo refresh_token as key. Add created + client IP.
 		$user_refresh_tokens[ $device ] = array(
 			'token'   => $refresh_token,
 			'expires' => $expires,
@@ -604,6 +605,7 @@ class Auth {
 		$user_refresh_tokens = get_user_meta( $user_id, 'jwt_auth_refresh_tokens', true );
 		$refresh_token       = $parts[1];
 
+		// @todo Validate expires
 		if ( empty( $user_refresh_tokens[ $device ] ) ||
 			$user_refresh_tokens[ $device ]['token'] !== $refresh_token
 			) {

--- a/class-auth.php
+++ b/class-auth.php
@@ -162,7 +162,7 @@ class Auth {
 		}
 
 		if ( isset( $_COOKIE['refresh_token'] ) ) {
-			$payload = $this->validate_token( $_COOKIE['refresh_token'], false );
+			$payload = $this->do_validate_token( $_COOKIE['refresh_token'] );
 
 			// If we receive a REST response, then validation failed.
 			if ( $payload instanceof WP_REST_Response ) {
@@ -348,58 +348,68 @@ class Auth {
 	 * Main validation function, this function try to get the Autentication
 	 * headers and decoded.
 	 *
-	 * @param string $token The token to validate. If omitted, the token is read from the HTTP Authorization header.
 	 * @param bool $return_response Either to return full WP_REST_Response or to return the payload only.
 	 *
 	 * @return WP_REST_Response | Array Returns WP_REST_Response or token's $payload.
 	 */
-	public function validate_token( $token = '', $return_response = true ) {
-		if ( $token === '' ) {
-			/**
-			 * Looking for the HTTP_AUTHORIZATION header, if not present just
-			 * return the user.
-			 */
-			$headerkey = apply_filters( 'jwt_auth_authorization_header', 'HTTP_AUTHORIZATION' );
-			$auth      = isset( $_SERVER[ $headerkey ] ) ? $_SERVER[ $headerkey ] : false;
+	public function validate_token( $return_response = true ) {
+		/**
+		 * Looking for the HTTP_AUTHORIZATION header, if not present just
+		 * return the user.
+		 */
+		$headerkey = apply_filters( 'jwt_auth_authorization_header', 'HTTP_AUTHORIZATION' );
+		$auth      = isset( $_SERVER[ $headerkey ] ) ? $_SERVER[ $headerkey ] : false;
 
-			// Double check for different auth header string (server dependent).
-			if ( ! $auth ) {
-				$auth = isset( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] : false;
-			}
-
-			if ( ! $auth ) {
-				return new WP_REST_Response(
-					array(
-						'success'    => false,
-						'statusCode' => 401,
-						'code'       => 'jwt_auth_no_auth_header',
-						'message'    => $this->messages['jwt_auth_no_auth_header'],
-						'data'       => array(),
-					),
-					401
-				);
-			}
-
-			/**
-			 * The HTTP_AUTHORIZATION is present, verify the format.
-			 * If the format is wrong return the user.
-			 */
-			list($token) = sscanf( $auth, 'Bearer %s' );
-
-			if ( ! $token ) {
-				return new WP_REST_Response(
-					array(
-						'success'    => false,
-						'statusCode' => 401,
-						'code'       => 'jwt_auth_bad_auth_header',
-						'message'    => $this->messages['jwt_auth_bad_auth_header'],
-						'data'       => array(),
-					),
-					401
-				);
-			}
+		// Double check for different auth header string (server dependent).
+		if ( ! $auth ) {
+			$auth = isset( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] : false;
 		}
 
+		if ( ! $auth ) {
+			return new WP_REST_Response(
+				array(
+					'success'    => false,
+					'statusCode' => 401,
+					'code'       => 'jwt_auth_no_auth_header',
+					'message'    => $this->messages['jwt_auth_no_auth_header'],
+					'data'       => array(),
+				),
+				401
+			);
+		}
+
+		/**
+		 * The HTTP_AUTHORIZATION is present, verify the format.
+		 * If the format is wrong return the user.
+		 */
+		list($token) = sscanf( $auth, 'Bearer %s' );
+
+		if ( ! $token ) {
+			return new WP_REST_Response(
+				array(
+					'success'    => false,
+					'statusCode' => 401,
+					'code'       => 'jwt_auth_bad_auth_header',
+					'message'    => $this->messages['jwt_auth_bad_auth_header'],
+					'data'       => array(),
+				),
+				401
+			);
+		}
+
+		return $this->do_validate_token( $auth, $return_response );
+	}
+
+	/**
+	 * Main validation function, this function try to get the Autentication
+	 * headers and decoded.
+	 *
+	 * @param string $token The token to validate.
+	 * @param bool $return_response Either to return full WP_REST_Response or to return the payload only.
+	 *
+	 * @return WP_REST_Response | Array Returns WP_REST_Response or token's $payload.
+	 */
+	public function do_validate_token( $token, $return_response = false ) {
 		// Get the Secret Key.
 		$secret_key = defined( 'JWT_AUTH_SECRET_KEY' ) ? JWT_AUTH_SECRET_KEY : false;
 
@@ -535,7 +545,7 @@ class Auth {
 				401
 			);
 		}
-		$payload = $this->validate_token( isset( $_COOKIE['refresh_token'] ) ? $_COOKIE['refresh_token'] : '', false );
+		$payload = $this->do_validate_token( $_COOKIE['refresh_token'] );
 
 		// If we receive a REST response, then validation failed.
 		if ( $payload instanceof WP_REST_Response ) {
@@ -588,7 +598,7 @@ class Auth {
 			return $user_id;
 		}
 
-		$payload = $this->validate_token( '', false );
+		$payload = $this->validate_token( false );
 
 		// If $payload is an error response, then return the default $user_id.
 		if ( $this->is_error_response( $payload ) ) {

--- a/class-auth.php
+++ b/class-auth.php
@@ -486,6 +486,26 @@ class Auth {
 	}
 
 	/**
+	 * Validates refresh token and generates new access token.
+	 *
+	 * @return WP_REST_Response Returns WP_REST_Response.
+	 */
+	public function refresh_token( $return_response = true ) {
+		$payload = $this->validate_token( false );
+
+		// If we receive a REST response, then validation failed.
+		if ($payload instanceof WP_REST_Response) {
+			return $payload;
+		}
+
+		// Generate a new access token.
+		$user = get_user_by( 'id', $payload->data->user->id );
+		$response = $this->generate_token( $user, false );
+
+		return $response;
+	}
+
+	/**
 	 * This is our Middleware to try to authenticate the user according to the token sent.
 	 *
 	 * @param int|bool $user_id User ID if one has been determined, false otherwise.

--- a/class-auth.php
+++ b/class-auth.php
@@ -152,12 +152,12 @@ class Auth {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
-					'statusCode' => 403,
+					'statusCode' => 500,
 					'code'       => 'jwt_auth_bad_config',
 					'message'    => __( 'JWT is not configured properly.', 'jwt-auth' ),
 					'data'       => array(),
 				),
-				403
+				500
 			);
 		}
 
@@ -183,12 +183,12 @@ class Auth {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
-					'statusCode' => 403,
+					'statusCode' => 401,
 					'code'       => $error_code,
 					'message'    => strip_tags( $user->get_error_message( $error_code ) ),
 					'data'       => array(),
 				),
-				403
+				401
 			);
 		}
 
@@ -372,11 +372,12 @@ class Auth {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
-					'statusCode' => 403,
+					'statusCode' => 401,
 					'code'       => 'jwt_auth_no_auth_header',
 					'message'    => $this->messages['jwt_auth_no_auth_header'],
 					'data'       => array(),
-				)
+				),
+				401
 			);
 		}
 
@@ -390,11 +391,12 @@ class Auth {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
-					'statusCode' => 403,
+					'statusCode' => 401,
 					'code'       => 'jwt_auth_bad_auth_header',
 					'message'    => $this->messages['jwt_auth_bad_auth_header'],
 					'data'       => array(),
-				)
+				),
+				401
 			);
 		}
 
@@ -405,12 +407,12 @@ class Auth {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
-					'statusCode' => 403,
+					'statusCode' => 401,
 					'code'       => 'jwt_auth_bad_config',
 					'message'    => __( 'JWT is not configured properly.', 'jwt-auth' ),
 					'data'       => array(),
 				),
-				403
+				401
 			);
 		}
 
@@ -425,12 +427,12 @@ class Auth {
 				return new WP_REST_Response(
 					array(
 						'success'    => false,
-						'statusCode' => 403,
+						'statusCode' => 401,
 						'code'       => 'jwt_auth_bad_iss',
 						'message'    => __( 'The iss do not match with this server.', 'jwt-auth' ),
 						'data'       => array(),
 					),
-					403
+					401
 				);
 			}
 
@@ -440,12 +442,12 @@ class Auth {
 				return new WP_REST_Response(
 					array(
 						'success'    => false,
-						'statusCode' => 403,
+						'statusCode' => 401,
 						'code'       => 'jwt_auth_bad_request',
 						'message'    => __( 'User ID not found in the token.', 'jwt-auth' ),
 						'data'       => array(),
 					),
-					403
+					401
 				);
 			}
 
@@ -457,12 +459,12 @@ class Auth {
 				return new WP_REST_Response(
 					array(
 						'success'    => false,
-						'statusCode' => 403,
+						'statusCode' => 401,
 						'code'       => 'jwt_auth_user_not_found',
 						'message'    => __( "User doesn't exist", 'jwt-auth' ),
 						'data'       => array(),
 					),
-					403
+					401
 				);
 			}
 
@@ -474,12 +476,12 @@ class Auth {
 				return new WP_REST_Response(
 					array(
 						'success'    => false,
-						'statusCode' => 403,
+						'statusCode' => 401,
 						'code'       => 'jwt_auth_obsolete_token',
 						'message'    => __( 'Token is obsolete', 'jwt-auth' ),
 						'data'       => array(),
 					),
-					403
+					401
 				);
 			}
 
@@ -505,12 +507,12 @@ class Auth {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
-					'statusCode' => 403,
+					'statusCode' => 401,
 					'code'       => 'jwt_auth_invalid_token',
 					'message'    => $e->getMessage(),
 					'data'       => array(),
 				),
-				403
+				401
 			);
 		}
 	}
@@ -525,11 +527,12 @@ class Auth {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
-					'statusCode' => 403,
+					'statusCode' => 401,
 					'code'       => 'jwt_auth_no_auth_header',
 					'message'    => $this->messages['jwt_auth_no_auth_header'],
 					'data'       => array(),
-				)
+				),
+				401
 			);
 		}
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $_COOKIE['refresh_token'];

--- a/class-auth.php
+++ b/class-auth.php
@@ -210,28 +210,12 @@ class Auth {
 	 * @return WP_REST_Response|string Return as raw token string or as a formatted WP_REST_Response.
 	 */
 	public function generate_token( $user, $return_raw = true ) {
+		$secret_key = defined( 'JWT_AUTH_SECRET_KEY' ) ? JWT_AUTH_SECRET_KEY : false;
 		$issued_at  = time();
 		$not_before = $issued_at;
 		$not_before = apply_filters( 'jwt_auth_not_before', $not_before, $issued_at );
 		$expire     = $issued_at + ( MINUTE_IN_SECONDS * 10 );
 		$expire     = apply_filters( 'jwt_auth_expire', $expire, $issued_at );
-
-		return $this->do_generate_token( $issued_at, $not_before, $expire, $user, $return_raw );
-	}
-
-	/**
-	 * Generate token
-	 *
-	 * @param int     $issued_at Unix timestamp of when the token was generated.
-	 * @param int     $not_before Unix timestamp of when the token becomes valid.
-	 * @param int     $expire Unix timestamp of when the token expires.
-	 * @param WP_User $user The WP_User object.
-	 * @param bool    $return_raw Whether or not to return as raw token string.
-	 *
-	 * @return WP_REST_Response|string Return as raw token string or as a formatted WP_REST_Response.
-	 */
-	private function do_generate_token( $issued_at, $not_before, $expire, $user, $return_raw = true ) {
-		$secret_key = defined( 'JWT_AUTH_SECRET_KEY' ) ? JWT_AUTH_SECRET_KEY : false;
 
 		$payload = array(
 			'iss'  => $this->get_iss(),
@@ -404,18 +388,6 @@ class Auth {
 			);
 		}
 
-		return $this->do_validate_token( $token, $return_response );
-	}
-
-	/**
-	 * Validates whether a token can be decoded and matches the issuer.
-	 *
-	 * @param string $token The token to validate.
-	 * @param bool   $return_response Either to return full WP_REST_Response or to return the payload only.
-	 *
-	 * @return WP_REST_Response | Array Returns WP_REST_Response or token's $payload.
-	 */
-	public function do_validate_token( $token, $return_response = false ) {
 		// Get the Secret Key.
 		$secret_key = defined( 'JWT_AUTH_SECRET_KEY' ) ? JWT_AUTH_SECRET_KEY : false;
 

--- a/class-auth.php
+++ b/class-auth.php
@@ -215,7 +215,7 @@ class Auth {
 		$issued_at  = time();
 		$not_before = $issued_at;
 		$not_before = apply_filters( 'jwt_auth_not_before', $not_before, $issued_at );
-		$expire     = $issued_at + HOUR_IN_SECONDS;
+		$expire     = $issued_at + (MINUTE_IN_SECONDS * 10);
 		$expire     = apply_filters( 'jwt_auth_expire', $expire, $issued_at );
 
 		return $this->do_generate_token( $issued_at, $not_before, $expire, $user, $return_raw );

--- a/class-setup.php
+++ b/class-setup.php
@@ -39,6 +39,11 @@ class Setup {
 		add_filter( 'rest_api_init', array( $this->auth, 'add_cors_support' ) );
 		add_filter( 'rest_pre_dispatch', array( $this->auth, 'rest_pre_dispatch' ), 10, 3 );
 		add_filter( 'determine_current_user', array( $this->auth, 'determine_current_user' ) );
+
+		if ( ! wp_next_scheduled( 'jwt_auth_purge_expired_refresh_tokens' )) {
+			wp_schedule_event( time(), 'weekly', 'jwt_auth_purge_expired_refresh_tokens' );
+		}
+		add_action( 'jwt_auth_purge_expired_refresh_tokens', array( $this, 'cron_purge_expired_refresh_tokens' ) );
 	}
 
 	/**
@@ -47,4 +52,42 @@ class Setup {
 	public function setup_text_domain() {
 		load_plugin_textdomain( 'jwt-auth', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 	}
+
+	/**
+	 * Cleans expired refresh tokens from user accounts.
+	 */
+	public function cron_purge_expired_refresh_tokens() {
+		global $wpdb;
+
+		$now = time();
+		$user_ids = $wpdb->get_col( $wpdb->prepare( "SELECT user_id FROM {$wpdb->usermeta}
+			WHERE meta_key = 'jwt_auth_refresh_tokens_expires_next'
+			AND meta_value <= %d
+		", $now ) );
+
+		foreach ($user_ids as $user_id) {
+			$user_refresh_tokens = get_user_meta( $user_id, 'jwt_auth_refresh_tokens', true );
+			if ( is_array( $user_refresh_tokens ) ) {
+				$expires_next = 0;
+				foreach ( $user_refresh_tokens as $key => $device ) {
+					if ( $device['expires'] <= $now ) {
+						unset( $user_refresh_tokens[ $key ] );
+					}
+					elseif ( $expires_next === 0 || $device['expires'] <= $expires_next ) {
+						$expires_next = $device['expires'];
+					}
+				}
+
+				if ( $user_refresh_tokens ) {
+					update_user_meta( $user_id, 'jwt_auth_refresh_tokens', $user_refresh_tokens );
+					update_user_meta( $user_id, 'jwt_auth_refresh_tokens_expires_next', $expires_next );
+				}
+				else {
+					delete_user_meta(  $user_id, 'jwt_auth_refresh_tokens' );
+					delete_user_meta(  $user_id, 'jwt_auth_refresh_tokens_expires_next' );
+				}
+			}
+		}
+	}
+
 }

--- a/class-setup.php
+++ b/class-setup.php
@@ -72,8 +72,7 @@ class Setup {
 				foreach ( $user_refresh_tokens as $key => $device ) {
 					if ( $device['expires'] <= $now ) {
 						unset( $user_refresh_tokens[ $key ] );
-					}
-					elseif ( $expires_next === 0 || $device['expires'] <= $expires_next ) {
+					} elseif ( $expires_next === 0 || $device['expires'] <= $expires_next ) {
 						$expires_next = $device['expires'];
 					}
 				}
@@ -81,8 +80,7 @@ class Setup {
 				if ( $user_refresh_tokens ) {
 					update_user_meta( $user_id, 'jwt_auth_refresh_tokens', $user_refresh_tokens );
 					update_user_meta( $user_id, 'jwt_auth_refresh_tokens_expires_next', $expires_next );
-				}
-				else {
+				} else {
 					delete_user_meta(  $user_id, 'jwt_auth_refresh_tokens' );
 					delete_user_meta(  $user_id, 'jwt_auth_refresh_tokens_expires_next' );
 				}

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,28 @@
         {
             "name": "Bagus",
             "email": "25834188+contactjavas@users.noreply.github.com"
+        },
+        {
+            "name": "Daniel Kudwien",
+            "email": "sun@makers99.com"
         }
     ],
     "minimum-stability": "stable",
     "require": {
         "firebase/php-jwt": "^5.2"
+    },
+    "require-dev": {
+        "php": ">=7.4",
+        "phpunit/phpunit": "^9.5",
+        "guzzlehttp/guzzle": "^7.4"
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "UsefulTeam\\Tests\\JwtAuth\\": "tests/src/",
+            "UsefulTeam\\Tests\\JwtAuth\\Fixtures\\": "tests/fixtures/"
+        }
     }
 }

--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -3,7 +3,7 @@
  * Plugin Name: JWT Auth
  * Plugin URI:  https://github.com/usefulteam/jwt-auth
  * Description: WordPress JWT Authentication.
- * Version:     2.0.0
+ * Version:     3.0.0
  * Author:      Useful Team
  * Author URI:  https://usefulteam.com
  * License:     GPL-3.0
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || die( "Can't access directly" );
 // Helper constants.
 define( 'JWT_AUTH_PLUGIN_DIR', rtrim( plugin_dir_path( __FILE__ ), '/' ) );
 define( 'JWT_AUTH_PLUGIN_URL', rtrim( plugin_dir_url( __FILE__ ), '/' ) );
-define( 'JWT_AUTH_PLUGIN_VERSION', '2.0.0' );
+define( 'JWT_AUTH_PLUGIN_VERSION', '3.0.0' );
 
 // Require composer.
 require __DIR__ . '/vendor/autoload.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,6 @@
   beStrictAboutOutputDuringTests="true"
   colors="true"
   >
-  <!-- @todo mark skipped tests failing -->
     <testsuites>
         <testsuite name="JWT Authentication Test Suite">
             <directory suffix=".php">./tests/src</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
   beStrictAboutOutputDuringTests="true"
   colors="true"
   >
+  <!-- @todo mark skipped tests failing -->
     <testsuites>
         <testsuite name="JWT Authentication Test Suite">
             <directory suffix=".php">./tests/src</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,12 @@
         </testsuite>
     </testsuites>
 
+    <php>
+      <env name="URL" value="http://localhost" />
+      <env name="USERNAME" value="admin" />
+      <env name="PASSWORD" value="password" />
+    </php>
+
     <!-- Filter for coverage reports. -->
     <coverage>
       <exclude>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+  bootstrap="vendor/autoload.php"
+  beStrictAboutTestsThatDoNotTestAnything="true"
+  beStrictAboutOutputDuringTests="true"
+  colors="true"
+  >
+    <testsuites>
+        <testsuite name="JWT Authentication Test Suite">
+            <directory suffix=".php">./tests/src</directory>
+        </testsuite>
+    </testsuites>
+
+    <!-- Filter for coverage reports. -->
+    <coverage>
+      <exclude>
+        <directory>./tests/fixtures</directory>
+        <directory>./vendor</directory>
+      </exclude>
+    </coverage>
+
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -73,11 +73,12 @@ When the plugin is activated, a new namespace is added.
 /jwt-auth/v1
 `
 
-Also, two new *POST* endpoints are added to this namespace.
+Also, three new *POST* endpoints are added to this namespace.
 
 `
 /wp-json/jwt-auth/v1/token
 /wp-json/jwt-auth/v1/token/validate
+/wp-json/jwt-auth/v1/token/refresh
 `
 
 ## Requesting/ Generating Token
@@ -89,6 +90,8 @@ Also, two new *POST* endpoints are added to this namespace.
 To generate token, submit a POST request to this endpoint. With `username` and `password` as the parameters.
 
 It will validates the user credentials, and returns success response including a token if the authentication is correct or returns an error response if the authentication is failed.
+
+You can use the optional parameter `device` with the device identifier to let user manage the device access in your profile. If this parameter is empty, it is ignored.
 
 = Sample of success response when trying to generate token: =
 
@@ -212,6 +215,51 @@ But if you want to test or validate the token manually, then send a **POST** req
 }
 `
 
+## Refreshing the Access Token
+
+For security reasons, third-party applications that are integrating with your authentication server will not store the user's username and password. Instead they will store the refresh token in a user-specific storage that is only accessible for the user. The refresh token can be used to re-authenticate as the same user and generate a new access token.
+
+When authenticating with `username` and `password` as the parameters to `/wp-json/jwt-auth/v1/token`, a refresh token is sent as a cookie in the response.
+
+`/wp-json/jwt-auth/v1/token`
+
+To generate new access token using the refresh token, submit a POST request to the token endpoint together with the `refresh_token` cookie.
+
+Use the optional parameter `device` with the device identifier to associate the token with that device.
+
+If the refresh token is valid, then you receive a new access token in the response.
+
+By default, each access token expires after 10 minutes.
+
+
+`/wp-json/jwt-auth/v1/token/refresh`
+
+To generate new refresh token using the refresh token, submit a POST request to the token refresh endpoint together with the `refresh_token` cookie.
+
+Use the optional parameter `device` with the device identifier to associate the refresh token with that device.
+
+If the refresh token is valid, then you receive a new refresh token as a cookie in the response.
+
+By default, each refresh token expires after 30 days.
+
+
+= Refresh Token Rotation =
+
+Whenever you are authenticating afresh or refreshing the refresh token, only the last issued refresh token remains valid. All previously issued refresh tokens can no longer be used.
+
+This means that a refresh token cannot be shared. To allow multiple devices to authenticate in parallel without losing access after another device re-authenticated, use the parameter `device` with the device identifier to associate the refresh token only with that device.
+
+`
+curl -F device="abc-def" -F username=myuser -F password=mypass /wp-json/jwt-auth/v1/token
+`
+`
+curl -F device="abc-def" -b "refresh_token=123.abcdef..." /wp-json/jwt-auth/v1/token
+`
+`
+curl -F device="abc-def" -b "refresh_token=123.abcdef..." /wp-json/jwt-auth/v1/token/refresh
+`
+
+
 ## Errors
 
 If the token is invalid an error will be returned. Here are some samples of errors:
@@ -264,7 +312,7 @@ If the token is invalid an error will be returned. Here are some samples of erro
 }
 `
 
-= Bad Request =
+= Incomplete Payload =
 
 `
 {
@@ -296,6 +344,18 @@ If the token is invalid an error will be returned. Here are some samples of erro
 	"statusCode": 403,
 	"code": "jwt_auth_invalid_token",
 	"message": "Expired token",
+	"data": []
+}
+`
+
+= Obsolete Token =
+
+`
+{
+	"success": false,
+	"statusCode": 403,
+	"code": "jwt_auth_obsolete_token",
+	"message": "Token is obsolete",
 	"data": []
 }
 `
@@ -416,6 +476,38 @@ Usage example:
  */
 add_filter(
 	'jwt_auth_expire',
+	function ( $expire, $issued_at ) {
+		// Modify the "expire" here.
+		return $expire;
+	},
+	10,
+	2
+);
+`
+
+= jwt_auth_refresh_expire =
+
+The `jwt_auth_refresh_expire` filter hook allows you to change the expiration date of the refresh token.
+
+Default Value:
+
+`
+time() + (DAY_IN_SECONDS * 30)
+`
+
+Usage example:
+
+`
+/**
+ * Change the refresh token's expiration time.
+ *
+ * @param int $expire The default expiration timestamp.
+ * @param int $issued_at The current time.
+ *
+ * @return int The custom refresh token expiration timestamp.
+ */
+add_filter(
+	'jwt_auth_refresh_expire',
 	function ( $expire, $issued_at ) {
 		// Modify the "expire" here.
 		return $expire;

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === JWT Auth - WordPress JSON Web Token Authentication ===
 
-Contributors: contactjavas
+Contributors: contactjavas, tha_sun
 Donate link: https://www.paypal.me/bagusjavas
 Tags: jwt, jwt-auth, token-authentication, json-web-token
 Requires at least: 5.2

--- a/readme.txt
+++ b/readme.txt
@@ -707,6 +707,11 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 3. Other error responses
 
 == Changelog ==
+= 3.0.0 =
+- New feature: Added support for refresh tokens.
+- Breaking change: Reduced default access token lifetime to 10 minutes.
+- Breaking bugfix: All authentication error responses are using the correct HTTP status code 401 (Unauthorized) instead of 403 (Forbidden) now.
+
 = 2.0.0 =
 - Breaking change: rename `jwt_auth_valid_token_extra` filter to `jwt_auth_extra_token_check`. Please check if you use this filter.
 - Breaking bugfix: the actual http statusCode didn't follow the response statusCode. Now the actual http statusCode follows the response statusCode.

--- a/readme.txt
+++ b/readme.txt
@@ -709,6 +709,7 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 == Changelog ==
 = 3.0.0 =
 - New feature: Added support for refresh tokens.
+- New feature: Added automated end-to-end tests using PHPUnit.
 - Breaking change: Reduced default access token lifetime to 10 minutes.
 - Breaking bugfix: All authentication error responses are using the correct HTTP status code 401 (Unauthorized) instead of 403 (Forbidden) now.
 

--- a/tests/src/AccessTokenTest.php
+++ b/tests/src/AccessTokenTest.php
@@ -16,10 +16,10 @@ final class AccessTokenTest extends TestCase {
         'password' => $this->password,
       ],
     ]);
-    $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(true, $body['success']);
     $this->assertEquals('jwt_auth_valid_credential', $body['code']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertEquals(true, $body['success']);
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -45,10 +45,10 @@ final class AccessTokenTest extends TestCase {
         'Authorization' => "Bearer $token",
       ],
     ]);
-    $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(true, $body['success']);
     $this->assertEquals('jwt_auth_valid_token', $body['code']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertEquals(true, $body['success']);
   }
 
   /**
@@ -62,10 +62,10 @@ final class AccessTokenTest extends TestCase {
         'Authorization' => "Bearer {$token}123",
       ],
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_invalid_token', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
   }
 
   /**
@@ -79,10 +79,10 @@ final class AccessTokenTest extends TestCase {
         'Authorization' => "Bearer {$token}",
       ],
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_no_auth_cookie', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
 
     $cookies = [
       'refresh_token' => $token,
@@ -93,10 +93,10 @@ final class AccessTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
       'cookies' => $cookies,
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_invalid_refresh_token', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
   }
 
   /**

--- a/tests/src/AccessTokenTest.php
+++ b/tests/src/AccessTokenTest.php
@@ -18,6 +18,7 @@ final class AccessTokenTest extends TestCase {
     ]);
     $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
+    // @todo assertEquals(mixed $expected, mixed $actual)
     $this->assertEquals($body['success'], true);
     $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
 

--- a/tests/src/AccessTokenTest.php
+++ b/tests/src/AccessTokenTest.php
@@ -18,9 +18,8 @@ final class AccessTokenTest extends TestCase {
     ]);
     $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    // @todo assertEquals(mixed $expected, mixed $actual)
-    $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+    $this->assertEquals(true, $body['success']);
+    $this->assertEquals('jwt_auth_valid_credential', $body['code']);
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -48,8 +47,8 @@ final class AccessTokenTest extends TestCase {
     ]);
     $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
+    $this->assertEquals(true, $body['success']);
+    $this->assertEquals('jwt_auth_valid_token', $body['code']);
   }
 
   /**
@@ -65,8 +64,8 @@ final class AccessTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_invalid_token', $body['code']);
   }
 
   /**
@@ -82,8 +81,8 @@ final class AccessTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_no_auth_cookie');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_no_auth_cookie', $body['code']);
 
     $cookies = [
       'refresh_token' => $token,
@@ -96,8 +95,8 @@ final class AccessTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_invalid_refresh_token');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_invalid_refresh_token', $body['code']);
   }
 
   /**
@@ -118,7 +117,7 @@ final class AccessTokenTest extends TestCase {
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals('jwt_auth_invalid_refresh_token', $body['code']);
     $this->assertEquals(401, $response->getStatusCode());
-    $this->assertEquals($body['success'], false);
+    $this->assertEquals(false, $body['success']);
   }
 
 }

--- a/tests/src/AccessTokenTest.php
+++ b/tests/src/AccessTokenTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace UsefulTeam\Tests\JwtAuth;
+
+use GuzzleHttp\Cookie\CookieJar;
+use PHPUnit\Framework\TestCase;
+
+final class AccessTokenTest extends TestCase {
+
+  use RestTestTrait;
+
+  public function testToken(): string {
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
+      'form_params' => [
+        'username' => $this->username,
+        'password' => $this->password,
+      ],
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+
+    $this->assertArrayHasKey('data', $body);
+    $this->assertArrayHasKey('token', $body['data']);
+    $this->token = $body['data']['token'];
+    $this->assertNotEmpty($this->token);
+
+    $cookie = $this->cookies->getCookieByName('refresh_token');
+    $this->refreshToken = $cookie->getValue();
+    $this->assertNotEmpty($this->refreshToken);
+    $this->assertNotEquals($this->token, $this->refreshToken);
+
+    return $this->token;
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenValidate(string $token): void {
+    $this->assertNotEmpty($token);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/validate', [
+      'headers' => [
+        'Authorization' => "Bearer $token",
+      ],
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenValidateWithInvalidToken(string $token): void {
+    $this->assertNotEmpty($token);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/validate', [
+      'headers' => [
+        'Authorization' => "Bearer {$token}123",
+      ],
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenRefreshWithInvalidToken(string $token): void {
+    $this->assertNotEmpty($token);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
+      'headers' => [
+        'Authorization' => "Bearer {$token}",
+      ],
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_no_auth_header');
+
+    $cookies = [
+      'refresh_token' => $token,
+    ];
+    $domain = $this->client->getConfig('base_uri')->getHost();
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenWithInvalidRefreshToken(string $token): void {
+    $this->assertNotEmpty($token);
+
+    $cookies = [
+      'refresh_token' => $token,
+    ];
+    $domain = $this->client->getConfig('base_uri')->getHost();
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+  }
+
+}

--- a/tests/src/AccessTokenTest.php
+++ b/tests/src/AccessTokenTest.php
@@ -82,7 +82,7 @@ final class AccessTokenTest extends TestCase {
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_no_auth_header');
+    $this->assertEquals($body['code'], 'jwt_auth_no_auth_cookie');
 
     $cookies = [
       'refresh_token' => $token,
@@ -96,7 +96,7 @@ final class AccessTokenTest extends TestCase {
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+    $this->assertEquals($body['code'], 'jwt_auth_invalid_refresh_token');
   }
 
   /**
@@ -114,10 +114,10 @@ final class AccessTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
       'cookies' => $cookies,
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals('jwt_auth_invalid_refresh_token', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
     $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
   }
 
 }

--- a/tests/src/RefreshTokenTest.php
+++ b/tests/src/RefreshTokenTest.php
@@ -22,8 +22,8 @@ final class RefreshTokenTest extends TestCase {
     // @todo Assert body.code first (debugging)
     $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+    $this->assertEquals(true, $body['success']);
+    $this->assertEquals('jwt_auth_valid_credential', $body['code']);
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -55,8 +55,8 @@ final class RefreshTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_invalid_token', $body['code']);
   }
 
   /**
@@ -77,7 +77,7 @@ final class RefreshTokenTest extends TestCase {
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals('jwt_auth_valid_credential', $body['code']);
     $this->assertEquals(200, $response->getStatusCode());
-    $this->assertEquals($body['success'], true);
+    $this->assertEquals(true, $body['success']);
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -110,8 +110,8 @@ final class RefreshTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_obsolete_token', $body['code']);
   }
 
   /**
@@ -132,7 +132,7 @@ final class RefreshTokenTest extends TestCase {
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals('jwt_auth_valid_token', $body['code']);
     $this->assertEquals(200, $response->getStatusCode());
-    $this->assertEquals($body['success'], true);
+    $this->assertEquals(true, $body['success']);
     $this->assertArrayNotHasKey('data', $body);
 
     // Discard the refresh_token cookie we set above to only retain the
@@ -160,8 +160,8 @@ final class RefreshTokenTest extends TestCase {
     $this->setCookie('refresh_token', $refreshToken1, $domain);
     $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh');
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
-    $this->assertEquals($body['success'], true);
+    $this->assertEquals('jwt_auth_valid_token', $body['code']);
+    $this->assertEquals(true, $body['success']);
     $this->assertEquals(200, $response->getStatusCode());
     $this->assertArrayNotHasKey('data', $body);
 
@@ -182,8 +182,8 @@ final class RefreshTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token');
     $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+    $this->assertEquals(true, $body['success']);
+    $this->assertEquals('jwt_auth_valid_credential', $body['code']);
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -204,8 +204,8 @@ final class RefreshTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token');
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_obsolete_token', $body['code']);
   }
 
   public function testTokenRefreshRotationByDevice() {
@@ -232,7 +232,7 @@ final class RefreshTokenTest extends TestCase {
         ],
       ]);
       $body = json_decode($response->getBody()->getContents(), true);
-      $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+      $this->assertEquals('jwt_auth_valid_credential', $body['code']);
       $cookie = $this->cookies->getCookieByName('refresh_token');
       $devices[$i]['refresh_token'] = $cookie->getValue();
       $this->assertNotEmpty($devices[$i]['refresh_token']);
@@ -255,7 +255,7 @@ final class RefreshTokenTest extends TestCase {
         ],
       ]);
       $body = json_decode($response->getBody()->getContents(), true);
-      $this->assertEquals($body['code'], 'jwt_auth_valid_token');
+      $this->assertEquals('jwt_auth_valid_token', $body['code']);
 
       // Discard the refresh_token cookie we set above to only retain the
       // refresh_token cookie from the response.
@@ -281,7 +281,7 @@ final class RefreshTokenTest extends TestCase {
         ],
       ]);
       $body = json_decode($response->getBody()->getContents(), true);
-      $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+      $this->assertEquals('jwt_auth_valid_credential', $body['code']);
       $this->assertArrayHasKey('token', $body['data']);
 
       $this->cookies->clear();
@@ -296,7 +296,7 @@ final class RefreshTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+    $this->assertEquals('jwt_auth_obsolete_token', $body['code']);
   }
 
   /**
@@ -312,8 +312,8 @@ final class RefreshTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_no_auth_cookie');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_no_auth_cookie', $body['code']);
 
     $cookies = [
       'refresh_token' => $refreshToken,
@@ -326,8 +326,8 @@ final class RefreshTokenTest extends TestCase {
     ]);
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+    $this->assertEquals(false, $body['success']);
+    $this->assertEquals('jwt_auth_obsolete_token', $body['code']);
   }
 
 }

--- a/tests/src/RefreshTokenTest.php
+++ b/tests/src/RefreshTokenTest.php
@@ -1,0 +1,255 @@
+<?php declare(strict_types=1);
+
+namespace UsefulTeam\Tests\JwtAuth;
+
+use GuzzleHttp\Cookie\CookieJar;
+use PHPUnit\Framework\TestCase;
+
+final class RefreshTokenTest extends TestCase {
+
+  use RestTestTrait;
+
+  public function testToken(): string {
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
+      'form_params' => [
+        'username' => $this->username,
+        'password' => $this->password,
+      ],
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+
+    $this->assertArrayHasKey('data', $body);
+    $this->assertArrayHasKey('token', $body['data']);
+    $this->token = $body['data']['token'];
+    $this->assertNotEmpty($this->token);
+
+    $cookie = $this->cookies->getCookieByName('refresh_token');
+    $this->refreshToken = $cookie->getValue();
+    $this->assertNotEmpty($this->refreshToken);
+    $this->assertNotEquals($this->token, $this->refreshToken);
+
+    return $this->refreshToken;
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenValidate(string $refreshToken): void {
+    $this->assertNotEmpty($refreshToken);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/validate', [
+      'headers' => [
+        'Authorization' => "Bearer $refreshToken",
+      ],
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenValidateWithInvalidToken(string $refreshToken): void {
+    $this->assertNotEmpty($refreshToken);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/validate', [
+      'headers' => [
+        'Authorization' => "Bearer {$refreshToken}123",
+      ],
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenWithRefreshToken(string $refreshToken): void {
+    $this->assertNotEmpty($refreshToken);
+
+    $cookies = [
+      'refresh_token' => $refreshToken,
+    ];
+    $domain = $this->client->getConfig('base_uri')->getHost();
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+
+    $this->assertArrayHasKey('data', $body);
+    $this->assertArrayHasKey('token', $body['data']);
+    $this->token = $body['data']['token'];
+    $this->assertNotEmpty($this->token);
+    $this->assertNotEquals($this->token, $refreshToken);
+
+    $cookie = $cookies->getCookieByName('refresh_token');
+    $this->refreshToken = $cookie->getValue();
+    $this->assertNotEmpty($this->refreshToken);
+    $this->assertEquals($this->refreshToken, $refreshToken);
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenWithInvalidRefreshToken(string $refreshToken): void {
+    $this->assertNotEmpty($refreshToken);
+
+    $cookies = [
+      'refresh_token' => $refreshToken . '123',
+    ];
+    $domain = $this->client->getConfig('base_uri')->getHost();
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenRefresh(string $refreshToken): string {
+    $this->assertNotEmpty($refreshToken);
+
+    $cookies = [
+      'refresh_token' => $refreshToken,
+    ];
+    $domain = $this->client->getConfig('base_uri')->getHost();
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
+    $this->assertArrayNotHasKey('data', $body);
+
+    $cookie = $cookies->getCookieByName('refresh_token');
+    $this->refreshToken = $cookie->getValue();
+    $this->assertNotEmpty($this->refreshToken);
+    $this->assertEquals($this->refreshToken, $refreshToken);
+
+    return $this->refreshToken;
+  }
+
+  /**
+   * @depends testToken
+   */
+  public function testTokenRefreshWithInvalidRefreshToken(string $refreshToken): void {
+    $this->assertNotEmpty($refreshToken);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
+      'headers' => [
+        'Authorization' => "Bearer {$refreshToken}",
+      ],
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_no_auth_header');
+
+    $cookies = [
+      'refresh_token' => $refreshToken,
+    ];
+    $domain = $this->client->getConfig('base_uri')->getHost();
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+  }
+
+  /**
+   * @depends testTokenRefresh
+   */
+  public function testTokenWithRotatedRefreshToken(string $refreshToken): void {
+    $this->assertNotEmpty($refreshToken);
+
+    $domain = $this->client->getConfig('base_uri')->getHost();
+
+    // Refresh the refresh token.
+    $cookies = [
+      'refresh_token' => $refreshToken,
+    ];
+    $cookies = CookieJar::fromArray($cookies, $domain);
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
+    $this->assertArrayNotHasKey('data', $body);
+
+    $cookie = $cookies->getCookieByName('refresh_token');
+    $currentRefreshToken = $cookie->getValue();
+    $this->assertNotEmpty($currentRefreshToken);
+    $this->assertNotEquals($currentRefreshToken, $refreshToken);
+
+    // Confirm the refresh token was rotated.
+    $this->assertNotEquals($refreshToken, $currentRefreshToken);
+
+    // Confirm the previous refresh token is no longer valid.
+    $cookies = [
+      'refresh_token' => $refreshToken,
+    ];
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
+
+    // Confirm the current refresh token is valid.
+    $cookies = [
+      'refresh_token' => $currentRefreshToken,
+    ];
+    $cookies = CookieJar::fromArray($cookies, $domain);
+
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
+      'cookies' => $cookies,
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+
+    $this->assertArrayHasKey('data', $body);
+    $this->assertArrayHasKey('token', $body['data']);
+    $this->token = $body['data']['token'];
+    $this->assertNotEmpty($this->token);
+    $this->assertNotEquals($this->token, $currentRefreshToken);
+
+    $cookie = $cookies->getCookieByName('refresh_token');
+    $this->refreshToken = $cookie->getValue();
+    $this->assertNotEmpty($this->refreshToken);
+    $this->assertEquals($this->refreshToken, $currentRefreshToken);
+    $this->assertNotEquals($this->refreshToken, $obsoleteRefreshToken);
+  }
+
+}

--- a/tests/src/RefreshTokenTest.php
+++ b/tests/src/RefreshTokenTest.php
@@ -26,6 +26,10 @@ final class RefreshTokenTest extends TestCase {
     $this->token = $body['data']['token'];
     $this->assertNotEmpty($this->token);
 
+    // Discard the refresh_token cookie we set above to only retain the
+    // refresh_token cookie from the response.
+    $this->cookies->clearSessionCookies();
+
     $cookie = $this->cookies->getCookieByName('refresh_token');
     $this->refreshToken = $cookie->getValue();
     $this->assertNotEmpty($this->refreshToken);
@@ -37,29 +41,12 @@ final class RefreshTokenTest extends TestCase {
   /**
    * @depends testToken
    */
-  public function testTokenValidate(string $refreshToken): void {
+  public function testTokenValidateWithRefreshToken(string $refreshToken): void {
     $this->assertNotEmpty($refreshToken);
 
     $response = $this->client->post('/wp-json/jwt-auth/v1/token/validate', [
       'headers' => [
-        'Authorization' => "Bearer $refreshToken",
-      ],
-    ]);
-    $this->assertEquals(200, $response->getStatusCode());
-    $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
-  }
-
-  /**
-   * @depends testToken
-   */
-  public function testTokenValidateWithInvalidToken(string $refreshToken): void {
-    $this->assertNotEmpty($refreshToken);
-
-    $response = $this->client->post('/wp-json/jwt-auth/v1/token/validate', [
-      'headers' => [
-        'Authorization' => "Bearer {$refreshToken}123",
+        'Authorization' => "Bearer {$refreshToken}",
       ],
     ]);
     $this->assertEquals(401, $response->getStatusCode());
@@ -83,10 +70,10 @@ final class RefreshTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
       'cookies' => $cookies,
     ]);
-    $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals('jwt_auth_valid_credential', $body['code']);
+    $this->assertEquals(200, $response->getStatusCode());
     $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -94,10 +81,12 @@ final class RefreshTokenTest extends TestCase {
     $this->assertNotEmpty($this->token);
     $this->assertNotEquals($this->token, $refreshToken);
 
+    // Discard the refresh_token cookie we set above to only retain the
+    // refresh_token cookie from the response.
+    $cookies->clearSessionCookies();
+
     $cookie = $cookies->getCookieByName('refresh_token');
-    $this->refreshToken = $cookie->getValue();
-    $this->assertNotEmpty($this->refreshToken);
-    $this->assertEquals($this->refreshToken, $refreshToken);
+    $this->assertEmpty($cookie);
   }
 
   /**
@@ -118,7 +107,7 @@ final class RefreshTokenTest extends TestCase {
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
+    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
   }
 
   /**
@@ -136,18 +125,83 @@ final class RefreshTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
       'cookies' => $cookies,
     ]);
-    $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals('jwt_auth_valid_token', $body['code']);
+    $this->assertEquals(200, $response->getStatusCode());
     $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
     $this->assertArrayNotHasKey('data', $body);
+
+    // Discard the refresh_token cookie we set above to only retain the
+    // refresh_token cookie from the response.
+    $cookies->clearSessionCookies();
 
     $cookie = $cookies->getCookieByName('refresh_token');
     $this->refreshToken = $cookie->getValue();
     $this->assertNotEmpty($this->refreshToken);
-    $this->assertEquals($this->refreshToken, $refreshToken);
+    $this->assertNotEquals($this->refreshToken, $refreshToken);
 
     return $this->refreshToken;
+  }
+
+  public function testTokenWithRotatedRefreshToken(): void {
+    // Not using @depends, because refresh token rotation relies on particular
+    // order.
+    $refreshToken1 = $this->testToken();
+    $this->assertNotEmpty($refreshToken1);
+
+    $domain = $this->client->getConfig('base_uri')->getHost();
+
+    // Fetch a new refresh token.
+    $this->cookies->clear();
+    $this->setCookie('refresh_token', $refreshToken1, $domain);
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh');
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertArrayNotHasKey('data', $body);
+
+    // Discard the refresh_token cookie we set above to only retain the
+    // refresh_token cookie from the response.
+    $this->cookies->clearSessionCookies();
+
+    $cookie = $this->cookies->getCookieByName('refresh_token');
+    $refreshToken2 = $cookie->getValue();
+    $this->assertNotEmpty($refreshToken2);
+
+    // Confirm the refresh token was rotated.
+    $this->assertNotEquals($refreshToken2, $refreshToken1);
+
+    // Confirm the rotated refresh token is valid.
+    $this->cookies->clear();
+    $this->setCookie('refresh_token', $refreshToken2, $domain);
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token');
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], true);
+    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
+
+    $this->assertArrayHasKey('data', $body);
+    $this->assertArrayHasKey('token', $body['data']);
+    $this->token = $body['data']['token'];
+    $this->assertNotEmpty($this->token);
+    $this->assertNotEquals($this->token, $refreshToken2);
+
+    // Discard the refresh_token cookie we set above to only retain the
+    // refresh_token cookie from the response.
+    $this->cookies->clearSessionCookies();
+
+    $cookie = $this->cookies->getCookieByName('refresh_token');
+    $this->assertEmpty($cookie);
+
+    // Confirm the previous refresh token is no longer valid.
+    $this->cookies->clear();
+    $this->setCookie('refresh_token', $refreshToken1, $domain);
+    $response = $this->client->post('/wp-json/jwt-auth/v1/token');
+    $this->assertEquals(401, $response->getStatusCode());
+    $body = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals($body['success'], false);
+    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
   }
 
   /**
@@ -164,7 +218,7 @@ final class RefreshTokenTest extends TestCase {
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_no_auth_header');
+    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
 
     $cookies = [
       'refresh_token' => $refreshToken,
@@ -179,77 +233,6 @@ final class RefreshTokenTest extends TestCase {
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals($body['success'], false);
     $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
-  }
-
-  /**
-   * @depends testTokenRefresh
-   */
-  public function testTokenWithRotatedRefreshToken(string $refreshToken): void {
-    $this->assertNotEmpty($refreshToken);
-
-    $domain = $this->client->getConfig('base_uri')->getHost();
-
-    // Refresh the refresh token.
-    $cookies = [
-      'refresh_token' => $refreshToken,
-    ];
-    $cookies = CookieJar::fromArray($cookies, $domain);
-    $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
-      'cookies' => $cookies,
-    ]);
-    $this->assertEquals(200, $response->getStatusCode());
-    $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_token');
-    $this->assertArrayNotHasKey('data', $body);
-
-    $cookie = $cookies->getCookieByName('refresh_token');
-    $currentRefreshToken = $cookie->getValue();
-    $this->assertNotEmpty($currentRefreshToken);
-    $this->assertNotEquals($currentRefreshToken, $refreshToken);
-
-    // Confirm the refresh token was rotated.
-    $this->assertNotEquals($refreshToken, $currentRefreshToken);
-
-    // Confirm the previous refresh token is no longer valid.
-    $cookies = [
-      'refresh_token' => $refreshToken,
-    ];
-    $cookies = CookieJar::fromArray($cookies, $domain);
-
-    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
-      'cookies' => $cookies,
-    ]);
-    $this->assertEquals(401, $response->getStatusCode());
-    $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_obsolete_token');
-
-    // Confirm the current refresh token is valid.
-    $cookies = [
-      'refresh_token' => $currentRefreshToken,
-    ];
-    $cookies = CookieJar::fromArray($cookies, $domain);
-
-    $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
-      'cookies' => $cookies,
-    ]);
-    $this->assertEquals(200, $response->getStatusCode());
-    $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals($body['success'], true);
-    $this->assertEquals($body['code'], 'jwt_auth_valid_credential');
-
-    $this->assertArrayHasKey('data', $body);
-    $this->assertArrayHasKey('token', $body['data']);
-    $this->token = $body['data']['token'];
-    $this->assertNotEmpty($this->token);
-    $this->assertNotEquals($this->token, $currentRefreshToken);
-
-    $cookie = $cookies->getCookieByName('refresh_token');
-    $this->refreshToken = $cookie->getValue();
-    $this->assertNotEmpty($this->refreshToken);
-    $this->assertEquals($this->refreshToken, $currentRefreshToken);
-    $this->assertNotEquals($this->refreshToken, $obsoleteRefreshToken);
   }
 
 }

--- a/tests/src/RefreshTokenTest.php
+++ b/tests/src/RefreshTokenTest.php
@@ -19,11 +19,10 @@ final class RefreshTokenTest extends TestCase {
         'password' => $this->password,
       ],
     ]);
-    // @todo Assert body.code first (debugging)
-    $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(true, $body['success']);
     $this->assertEquals('jwt_auth_valid_credential', $body['code']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertEquals(true, $body['success']);
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -53,10 +52,10 @@ final class RefreshTokenTest extends TestCase {
         'Authorization' => "Bearer {$refreshToken}",
       ],
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_invalid_token', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
   }
 
   /**
@@ -108,10 +107,10 @@ final class RefreshTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token', [
       'cookies' => $cookies,
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_obsolete_token', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
   }
 
   /**
@@ -161,8 +160,8 @@ final class RefreshTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh');
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals('jwt_auth_valid_token', $body['code']);
-    $this->assertEquals(true, $body['success']);
     $this->assertEquals(200, $response->getStatusCode());
+    $this->assertEquals(true, $body['success']);
     $this->assertArrayNotHasKey('data', $body);
 
     // Discard the refresh_token cookie we set above to only retain the
@@ -180,10 +179,10 @@ final class RefreshTokenTest extends TestCase {
     $this->cookies->clear();
     $this->setCookie('refresh_token', $refreshToken2, $domain);
     $response = $this->client->post('/wp-json/jwt-auth/v1/token');
-    $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(true, $body['success']);
     $this->assertEquals('jwt_auth_valid_credential', $body['code']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertEquals(true, $body['success']);
 
     $this->assertArrayHasKey('data', $body);
     $this->assertArrayHasKey('token', $body['data']);
@@ -202,10 +201,10 @@ final class RefreshTokenTest extends TestCase {
     $this->cookies->clear();
     $this->setCookie('refresh_token', $refreshToken1, $domain);
     $response = $this->client->post('/wp-json/jwt-auth/v1/token');
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_obsolete_token', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
   }
 
   public function testTokenRefreshRotationByDevice() {
@@ -310,10 +309,10 @@ final class RefreshTokenTest extends TestCase {
         'Authorization' => "Bearer {$refreshToken}",
       ],
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_no_auth_cookie', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
 
     $cookies = [
       'refresh_token' => $refreshToken,
@@ -324,10 +323,10 @@ final class RefreshTokenTest extends TestCase {
     $response = $this->client->post('/wp-json/jwt-auth/v1/token/refresh', [
       'cookies' => $cookies,
     ]);
-    $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
-    $this->assertEquals(false, $body['success']);
     $this->assertEquals('jwt_auth_obsolete_token', $body['code']);
+    $this->assertEquals(401, $response->getStatusCode());
+    $this->assertEquals(false, $body['success']);
   }
 
 }

--- a/tests/src/RefreshTokenTest.php
+++ b/tests/src/RefreshTokenTest.php
@@ -5,6 +5,9 @@ namespace UsefulTeam\Tests\JwtAuth;
 use GuzzleHttp\Cookie\CookieJar;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @small
+ */
 final class RefreshTokenTest extends TestCase {
 
   use RestTestTrait;
@@ -16,6 +19,7 @@ final class RefreshTokenTest extends TestCase {
         'password' => $this->password,
       ],
     ]);
+    // @todo Assert body.code first (debugging)
     $this->assertEquals(200, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals($body['success'], true);

--- a/tests/src/RefreshTokenTest.php
+++ b/tests/src/RefreshTokenTest.php
@@ -222,7 +222,7 @@ final class RefreshTokenTest extends TestCase {
     $this->assertEquals(401, $response->getStatusCode());
     $body = json_decode($response->getBody()->getContents(), true);
     $this->assertEquals($body['success'], false);
-    $this->assertEquals($body['code'], 'jwt_auth_invalid_token');
+    $this->assertEquals($body['code'], 'jwt_auth_no_auth_cookie');
 
     $cookies = [
       'refresh_token' => $refreshToken,

--- a/tests/src/RestTestTrait.php
+++ b/tests/src/RestTestTrait.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\SetCookie;
 
 /**
- *
+ * Shared methods for REST end-to-end tests.
  *
  * Hint: You can use PHP shell execution operators to debug tests; e.g., to see
  * the current refresh token used in the test and the refresh tokens stored for
@@ -28,7 +28,7 @@ trait RestTestTrait {
   protected function setUp(): void {
     $this->cookies = new CookieJar();
     $options = [
-      'base_uri' => 'http://front.bnn.local',
+      'base_uri' => $_ENV['URL'],
       'http_errors' => false,
       'cookies' => $this->cookies,
       // PHP's cURL library attempts to resolve domains with IPv6, causing a
@@ -50,8 +50,8 @@ trait RestTestTrait {
       $options['debug'] = true;
     }
     $this->client = new Client($options);
-    $this->username = '100100100';
-    $this->password = 'asdlkj';
+    $this->username = $_ENV['USERNAME'];
+    $this->password = $_ENV['PASSWORD'];
   }
 
   protected function setCookie($name, $value, $domain): CookieJar {

--- a/tests/src/RestTestTrait.php
+++ b/tests/src/RestTestTrait.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace UsefulTeam\Tests\JwtAuth;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+
+trait RestTestTrait {
+
+  protected $client;
+  protected $cookies;
+  protected $username;
+  protected $password;
+  protected $token;
+  protected $refreshToken;
+
+  protected function setUp(): void {
+    $this->cookies = new CookieJar();
+    $this->client = new Client([
+      'base_uri' => 'http://front.bnn.local',
+      'http_errors' => false,
+      'cookies' => $this->cookies,
+      // PHP's cURL library attempts to resolve domains with IPv6, causing a
+      // long delay on local dev machines, since typically not set up for IPv6.
+      // @see https://stackoverflow.com/questions/17814925/php-curl-consistently-taking-15s-to-resolve-dns
+      // @see https://www.php.net/manual/de/function.curl-setopt.php
+      // @see https://wordpress.org/support/topic/curl-error-28-operation-timed-out-after-5000-milliseconds-with-0-bytes-received/
+      // @see https://docs.presscustomizr.com/article/326-how-to-fix-a-curl-error-28-connection-timed-out-in-wordpress
+      // How to avoid this:
+      // - Add to /etc/hosts: "::1 example.com"
+      // - Add to Apache httpd.conf: "Listen ::1"
+      // - Listen to any IP: "<VirtualHost *:80>"
+      'force_ip_resolve' => 'v4',
+      'curl' => [
+        CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
+      ],
+    ]);
+    $this->username = '100100100';
+    $this->password = 'asdlkj';
+  }
+
+}

--- a/tests/src/RestTestTrait.php
+++ b/tests/src/RestTestTrait.php
@@ -6,6 +6,16 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\SetCookie;
 
+/**
+ *
+ *
+ * Hint: You can use PHP shell execution operators to debug tests; e.g., to see
+ * the current refresh token used in the test and the refresh tokens stored for
+ * a certain user:
+ * ```
+ *   var_dump($refreshToken, `wp user meta get 87310 jwt_auth_refresh_tokens`);
+ * ```
+ */
 trait RestTestTrait {
 
   protected $client;

--- a/tests/src/RestTestTrait.php
+++ b/tests/src/RestTestTrait.php
@@ -4,6 +4,7 @@ namespace UsefulTeam\Tests\JwtAuth;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\SetCookie;
 
 trait RestTestTrait {
 
@@ -16,7 +17,7 @@ trait RestTestTrait {
 
   protected function setUp(): void {
     $this->cookies = new CookieJar();
-    $this->client = new Client([
+    $options = [
       'base_uri' => 'http://front.bnn.local',
       'http_errors' => false,
       'cookies' => $this->cookies,
@@ -34,9 +35,23 @@ trait RestTestTrait {
       'curl' => [
         CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
       ],
-    ]);
+    ];
+    if (in_array('--debug', $_SERVER['argv'], true)) {
+      $options['debug'] = true;
+    }
+    $this->client = new Client($options);
     $this->username = '100100100';
     $this->password = 'asdlkj';
+  }
+
+  protected function setCookie($name, $value, $domain): CookieJar {
+    $this->cookies->setCookie(new SetCookie([
+        'Domain'  => $domain,
+        'Name'    => $name,
+        'Value'   => $value,
+        'Discard' => true,
+    ]));
+    return $this->cookies;
   }
 
 }


### PR DESCRIPTION
Resolves #1 

Problem
- Clients that do not want to or cannot store the actual login credentials of the user (username, password) are not able to re-authenticate after the access token expires.

Goal
- Establish common JWT authentication flow for third-party apps.

Proposed solution
1. `/token` generates a new access token.
    - Either by passing username/password combo (as before). This returns a refresh token in a HttpOnly cookie.
    - Or by passing a valid refresh token in a cookie.
    - The refresh token is also a JWT, but has a (very) long TTL.
2. ~`/token/validate` validates whether a token is still valid. Token can be an access token or refresh token.~
3. `/token/refresh` generates a new refresh token and sends it in a HttpOnly cookie.
    - Requires a valid refresh token to be sent in a cookie.
4. Reduce the default TTL of the existing (access) tokens to one hour.

Resources
- https://hasura.io/blog/best-practices-of-using-jwt-with-graphql/#refresh_token_persistance

To clarify
- [x] Does the addition of `refreshToken` in the `/token` response require a major version bump?
    - ~No – The question is obsolete as the refresh token is sent as a HttpOnly cookie now and the response parameters in the response body are not changed. Therefore a REST API version bump is not necessary.~
    - Yes – There are two breaking changes; the reduction of the access token lifetime and the corrected status codes of error responses.
    - ~~If yes, only the plugin version or also the REST API version?~~
    - ~~Missing data point: How many _actual_ implementations of this plugin in production environments can there realistically be in the wild without a refresh token concept? And assuming all of those are very custom anyway, is a plugin major version bump (without REST API version bump) sufficient?~~
    - ~~#19 attempted/suggested a REST version bump, but the changes in there are by far incomplete. A REST version bump would have to ensure that v1 remains to work as in the past, in parallel to a new v2.~~

Remaining todos

- [x] Correct wrong response codes for invalid authorization responses to be 401 instead of 403; see https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
- [x] Save last refresh token in user meta (by device ID)
- [x] Validate refresh token against stored one in user meta
- [x] Do not allow a refresh token to be used as access token (marker in payload)
- [x] Save soonest refresh token expiration date in separate user meta
- [x] Weekly cron to prune expired refresh tokens (resetting soonest expiration date)
- [x] Replace hardcoded test dummy host, username, password values with environment variables
- [x] ~Add an option or constant to emit the refresh token in the response body instead (https://github.com/usefulteam/jwt-auth/issues/1#issuecomment-895468941)~ moved into #59 
- [x] Update docs (cookie instead of response parameter)
- [x] Increase the plugin version

---
From https://github.com/usefulteam/jwt-auth/issues/1#issuecomment-867050042: The general idea is that the client should not store the username/password credentials themselves. It should only store the refresh token. The common flow looks like this:

### Authenticate with actual user login credentials to retrieve refresh token
```console
$ curl -F device=abc-def -F username=user -F password=pass https://example.com/wp-json/jwt-auth/v1/token
```
Response:
```
Set-Cookie: refresh_token=1234.3c5ce9df9fac63bfcface7f7bae0db12273c9dc4275cd5554f78d2853eddc3c0; expires=Wed, 01-Jun-2022 12:00:00 GMT; Max-Age=2592000; path=/; domain=.example.com; HttpOnly
```
```json
{
  "success": true,
  "statusCode": 200,
  "code": "jwt_auth_valid_credential",
  "message": "Credential is valid",
  "data": {
    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvc2VydmljZS50ZXN0LmJubi5kZSIsImlhdCI6MTYyNDQ1NzA2MSwibmJmIjoxNjI0NDU3MDYxLCJleHAiOjE2MjQ0NjA2NjEsImRhdGEiOnsidXNlciI6eyJpZCI6NTA1NjUsImRldmljZSI6IiIsInBhc3MiOm51bGx9fX0.yYmLkcoF6mYoI6naAUv_qvOgfojm2cTG3HW-CvSkkj0",
  }
}
```

### Authenticate with refresh token to create new access token
```console
$ curl -F device=abc-def -b \
'refresh_token=1234.3c5ce9df9fac63bfcface7f7bae0db12273c9dc4275cd5554f78d2853eddc3c0' \
https://example.com/wp-json/jwt-auth/v1/token
```
Response:
```json
{
  "success": true,
  "statusCode": 200,
  "code": "jwt_auth_valid_credential",
  "message": "Credential is valid",
  "data": {
    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvc2VydmljZS50ZXN0LmJubi5kZSIsImlhdCI6MTYyNDQ1NzA2MSwibmJmIjoxNjI0NDU3MDYxLCJleHAiOjE2MjQ0NjA2NjEsImRhdGEiOnsidXNlciI6eyJpZCI6NTA1NjUsImRldmljZSI6IiIsInBhc3MiOm51bGx9fX0.yYmLkcoF6mYoI6naAUv_qvOgfojm2cTG3HW-CvSkkj0",
  }
}
```

### Refresh the refresh token
```console
$ curl -F device=abc-def -b \
'refresh_token=1234.3c5ce9df9fac63bfcface7f7bae0db12273c9dc4275cd5554f78d2853eddc3c0' \
https://example.com/wp-json/jwt-auth/v1/token/refresh
```
Response:
```
Set-Cookie: refresh_token=1234.bc4345f6d43611a2988a8cff7e110379f1b32d7c2bd9c6feeacad2f89a7babd4; expires=Thu, 01-Jul-2022 16:10:13 GMT; Max-Age=2592000; path=/; domain=.example.com; HttpOnly
```
```json
{
  "success": true,
  "statusCode": 200,
  "code": "jwt_auth_valid_credential",
  "message": "Credential is valid",
  "data": {}
}
```
Note: The `/token/refresh` response only supplies a new refresh token. It does not generate a new access token.