### PR TITLE
Fixed Auth and Devices class methods cannot be accessed from integration plugins.

### DIFF
--- a/class-setup.php
+++ b/class-setup.php
@@ -11,19 +11,34 @@ namespace JWTAuth;
  * Setup JWT Auth.
  */
 class Setup {
+
+	private static $instance;
+	public $auth;
+	public $devices;
+
+	/**
+	 * Constructs singleton.
+	 */
+	public static function getInstance() {
+		if (!isset(self::$instance)) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
 	/**
 	 * Setup action & filter hooks.
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'setup_text_domain' ) );
 
-		$auth    = new Auth();
-		$devices = new Devices();
+		$this->auth    = new Auth();
+		$this->devices = new Devices();
 
-		add_action( 'rest_api_init', array( $auth, 'register_rest_routes' ) );
-		add_filter( 'rest_api_init', array( $auth, 'add_cors_support' ) );
-		add_filter( 'rest_pre_dispatch', array( $auth, 'rest_pre_dispatch' ), 10, 3 );
-		add_filter( 'determine_current_user', array( $auth, 'determine_current_user' ) );
+		add_action( 'rest_api_init', array( $this->auth, 'register_rest_routes' ) );
+		add_filter( 'rest_api_init', array( $this->auth, 'add_cors_support' ) );
+		add_filter( 'rest_pre_dispatch', array( $this->auth, 'rest_pre_dispatch' ), 10, 3 );
+		add_filter( 'determine_current_user', array( $this->auth, 'determine_current_user' ) );
 	}
 
 	/**


### PR DESCRIPTION
Problem
* When trying to implement custom integration code outside of the jwt-auth plugin, the methods of the Auth and Devices class instances cannot be accessed.

Cause
* The instances of the classes are not made available by the jwt-auth plugin.

Proposed solution
1. Convert the class `JWTAuth\Setup` into a singleton, so that `JWTAuth\Setup::getInstance()` allows access to the instantiated classes.

Notes
* Instead of making the `$auth` and `$devices` properties public, we can also consider to add dedicated `Setup::getAuth()` and `Setup::getDevices()` methods.
