### PR TITLE
Wordpress login support

### DIFF
--- a/class-setup.php
+++ b/class-setup.php
@@ -21,6 +21,7 @@ class Setup {
 		$devices = new Devices();
 
 		add_action( 'rest_api_init', array( $auth, 'register_rest_routes' ) );
+		add_action( 'wp_login', array($auth, 'wp_login_hook') );
 		add_filter( 'rest_api_init', array( $auth, 'add_cors_support' ) );
 		add_filter( 'rest_pre_dispatch', array( $auth, 'rest_pre_dispatch' ), 10, 3 );
 		add_filter( 'determine_current_user', array( $auth, 'determine_current_user' ) );


### PR DESCRIPTION
### Dear UsefulTeam!

I am not sure, how this plugin gonna change over the time.
I tought these features would be best implemented in the plugin itself.

**Adding Wordpress login support**

1. Via setting a cookie - filter: _jwt_set_cookie_
2. Via performing an action - filter: _jwt_do_hook_ , action: _jwt_wp_login_

