### PR TITLE
Fix "PHP Notice:  Undefined property: stdClass::$pass"

### DIFF
--- a/class-devices.php
+++ b/class-devices.php
@@ -97,7 +97,7 @@ class Devices {
 		// Check if user changed the password.
 		$pass = get_user_meta( $user->ID, 'jwt_auth_pass', true );
 
-		if ( $payload->data->user->pass !== $pass ) {
+		if ( isset( $payload->data->user->pass ) && $payload->data->user->pass !== $pass ) {
 			return 'password changed';
 		}
 


### PR DESCRIPTION
The newest updates introduces a bug, there is a PHP notice:
```PHP Notice:  Undefined property: stdClass::$pass in …/wp-content/plugins/jwt-auth/class-devices.php on line 99```
