### PR TITLE
Fixed third-party plugins cannot access the global Setup class singleton.

### DIFF
--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -29,4 +29,4 @@ require __DIR__ . '/class-auth.php';
 require __DIR__ . '/class-setup.php';
 require __DIR__ . '/class-devices.php';
 
-new JWTAuth\Setup();
+JWTAuth\Setup::getInstance();


### PR DESCRIPTION
Use the singleton pattern that is already in the JWTAuth\Setup class so third party plugins can get the global instance.