### PR TITLE
Removed whitelist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,53 +159,6 @@ The **jwt-auth** will intercept every call to the server and will look for the a
 
 If the token is valid, the API call flow will continue as always.
 
-## Whitelisting Endpoints
-
-Every call to the server (except the token creation some default whitelist) will be intercepted. However, you might need to whitelist some endpoints. You can use `jwt_auth_whitelist` filter to do it. Please simply add this filter directly (without hook). Or, you can add it to `plugins_loaded`. Adding this filter inside `init` (or later) will not work. 
-
-If you're adding the filter inside theme and the whitelisting doesn't work, please create a small 1 file plugin and add your filter there.
-
-```php
-add_filter( 'jwt_auth_whitelist', function ( $endpoints ) {
-	$your_endpoints = array(
-		'/wp-json/custom/v1/webhook/*',
-		'/wp-json/custom/v1/otp/*',
-		'/wp-json/custom/v1/account/check',
-		'/wp-json/custom/v1/register',
-	);
-
-	return array_unique( array_merge( $endpoints, $your_endpoints ) );
-} );
-```
-
-## Default Whitelisted Endpoints
-
-We whitelist some endpoints by default. This is to prevent error regarding WordPress & WooCommerce. These are the default whitelisted endpoints (without trailing *&#42;* char):
-
-```php
-// Whitelist some endpoints by default (without trailing * char).
-$default_whitelist = array(
-	// WooCommerce namespace.
-	$rest_api_slug . '/wc/',
-	$rest_api_slug . '/wc-auth/',
-	$rest_api_slug . '/wc-analytics/',
-
-	// WordPress namespace.
-	$rest_api_slug . '/wp/v2/',
-);
-```
-
-You might want to **remove** or modify the existing **default whitelist**. You can use `jwt_auth_default_whitelist` filter to do it. Please simply add this filter directly (without hook). Or, you can add it to `plugins_loaded`. Adding this filter inside `init` (or later) will not work. 
-
-If you're adding the filter inside theme and the it doesn't work, please create a small 1 file plugin and add your filter there. It should fix the issue.
-
-```php
-add_filter( 'jwt_auth_default_whitelist', function ( $default_whitelist ) {
-	// Modify the $default_whitelist here.
-	return $default_whitelist;
-} );
-```
-
 ## Validating Token
 
 You likely **don't need** to validate the token your self. The plugin handle it for you like explained above.

--- a/class-auth.php
+++ b/class-auth.php
@@ -622,7 +622,10 @@ class Auth {
 
 		$payload = $this->validate_token( false );
 
-		// If $payload is an error response, authentication failed.
+		// If $payload is an error response, then the client did not send a token,
+		// or the token is invalid, the client uses a different way to authenticate,
+		// or the endpoint does not require authentication.
+		// Let the endpoint do its regular access checks.
 		if ( $this->is_error_response( $payload ) ) {
 			return $user_id;
 		}

--- a/class-auth.php
+++ b/class-auth.php
@@ -622,111 +622,13 @@ class Auth {
 
 		$payload = $this->validate_token( false );
 
-		// If $payload is an error response, then return the default $user_id.
+		// If $payload is an error response, authentication failed.
 		if ( $this->is_error_response( $payload ) ) {
-			if ( 'jwt_auth_no_auth_header' === $payload->data['code'] ||
-				'jwt_auth_bad_auth_header' === $payload->data['code']
-			) {
-				$request_uri   = $_SERVER['REQUEST_URI'];
-				$rest_api_slug = home_url( '/' . $this->rest_api_slug, 'relative' );
-
-				if ( strpos( $request_uri, $rest_api_slug . '/jwt-auth/v1/token' ) !== 0 ) {
-					// Whitelist some endpoints by default (without trailing * char).
-					$default_whitelist = array(
-						// WooCommerce namespace.
-						$rest_api_slug . '/wc/',
-						$rest_api_slug . '/wc-admin/',
-						$rest_api_slug . '/wc-auth/',
-						$rest_api_slug . '/wc-analytics/',
-
-						// WordPress namespace.
-						$rest_api_slug . '/wp/v2/',
-						$rest_api_slug . '/oembed/',
-					);
-
-					// Well, we let you adjust this default whitelist :).
-					$default_whitelist = apply_filters( 'jwt_auth_default_whitelist', $default_whitelist );
-
-					$is_ignored = false;
-
-					foreach ( $default_whitelist as $endpoint ) {
-						if ( false !== stripos( $request_uri, $endpoint ) ) {
-							$is_ignored = true;
-
-							break;
-						}
-					}
-
-					if ( ! $is_ignored ) {
-						if ( ! $this->is_whitelisted() ) {
-							$this->jwt_error = $payload;
-						}
-					}
-				}
-			} else {
-				$this->jwt_error = $payload;
-			}
-
 			return $user_id;
 		}
 
 		// Everything is ok here, return the user ID stored in the token.
 		return $payload->data->user->id;
-	}
-
-	/**
-	 * Check whether or not current endpoint is whitelisted.
-	 *
-	 * @return bool
-	 */
-	public function is_whitelisted() {
-		$whitelist = apply_filters( 'jwt_auth_whitelist', array() );
-
-		if ( empty( $whitelist ) || ! is_array( $whitelist ) ) {
-			return false;
-		}
-
-		$request_uri    = $_SERVER['REQUEST_URI'];
-		$request_method = $_SERVER['REQUEST_METHOD'];
-
-		$prefix      = get_option( 'permalink_structure' ) ? rest_get_url_prefix() : '?rest_route=/';
-		$split       = explode( $prefix, $request_uri );
-		$request_uri = '/' . $prefix . ( ( count( $split ) > 1 ) ? $split[1] : $split[0] );
-
-		// Only use string before "?" sign if permalink is enabled.
-		if ( get_option( 'permalink_structure' ) && false !== stripos( $request_uri, '?' ) ) {
-			$split       = explode( '?', $request_uri );
-			$request_uri = $split[0];
-		}
-
-		// Let's remove trailingslash for easier checking.
-		$request_uri = untrailingslashit( $request_uri );
-
-		foreach ( $whitelist as $endpoint ) {
-			if ( is_array( $endpoint ) ) {
-				$method = $endpoint['method'];
-				$path   = $endpoint['path'];
-			} else {
-				$method = null;
-				$path   = $endpoint;
-			}
-			// If the endpoint doesn't contain * sign.
-			if ( false === stripos( $path, '*' ) ) {
-				$path = untrailingslashit( $path );
-
-				if ( $path === $request_uri && ( ! isset( $method ) || $method === $request_method ) ) {
-					return true;
-				}
-			} else {
-				$regex = '/' . str_replace( '/', '\/', $path ) . '/';
-
-				if ( preg_match( $regex, $request_uri ) && ( ! isset( $method ) || $method === $request_method ) ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -146,53 +146,6 @@ The **jwt-auth** will intercept every call to the server and will look for the a
 
 If the token is valid, the API call flow will continue as always.
 
-## Whitelisting Endpoints
-
-Every call to the server (except the token creation some default whitelist) will be intercepted. However, you might need to whitelist some endpoints. You can use `jwt_auth_whitelist` filter to do it. Please simply add this filter directly (without hook). Or, you can add it to `plugins_loaded`. Adding this filter inside `init` (or later) will not work. 
-
-If you're adding the filter inside theme and the whitelisting doesn't work, please create a small 1 file plugin and add your filter there.
-
-`
-add_filter( 'jwt_auth_whitelist', function ( $endpoints ) {
-	$your_endpoints = array(
-		'/wp-json/custom/v1/webhook/*',
-		'/wp-json/custom/v1/otp/*',
-		'/wp-json/custom/v1/account/check',
-		'/wp-json/custom/v1/register',
-	);
-
-	return array_unique( array_merge( $endpoints, $your_endpoints ) );
-} );
-`
-
-## Default Whitelisted Endpoints
-
-We whitelist some endpoints by default. This is to prevent error regarding WordPress & WooCommerce. These are the default whitelisted endpoints (without trailing *&#42;* char):
-
-`
-// Whitelist some endpoints by default (without trailing * char).
-$default_whitelist = array(
-	// WooCommerce namespace.
-	$rest_api_slug . '/wc/',
-	$rest_api_slug . '/wc-auth/',
-	$rest_api_slug . '/wc-analytics/',
-
-	// WordPress namespace.
-	$rest_api_slug . '/wp/v2/',
-);
-`
-
-You might want to **remove** or modify the existing **default whitelist**. You can use `jwt_auth_default_whitelist` filter to do it. Please simply add this filter directly (without hook). Or, you can add it to `plugins_loaded`. Adding this filter inside `init` (or later) will not work. 
-
-If you're adding the filter inside theme and the it doesn't work, please create a small 1 file plugin and add your filter there. It should fix the issue.
-
-`
-add_filter( 'jwt_auth_default_whitelist', function ( $default_whitelist ) {
-	// Modify the $default_whitelist here.
-	return $default_whitelist;
-} );
-`
-
 ## Validating Token
 
 You likely **don't need** to validate the token your self. The plugin handle it for you like explained above.
@@ -780,10 +733,6 @@ define('JWT_AUTH_CORS_ENABLE', true);
 Finally activate the plugin within the plugin dashboard.
 
 == Frequently Asked Questions ==
-= Now almost all REST routes are intercepted. How to exclude some routes/ endpoints? =
-
-There's `jwt_auth_whitelist` that you can use to whitelist specific endpoints. For more information, pease read **Whitelisting Endpoints** section in the Description tab.
-
 = Do you have GitHub repository for this plugin? =
 
 You can visit the GitHub repository [here](https://github.com/usefulteam/jwt-auth/)
@@ -804,6 +753,7 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 - New feature: Added automated end-to-end tests using PHPUnit.
 - Breaking change: Reduced default access token lifetime to 10 minutes.
 - Breaking bugfix: All authentication error responses are using the correct HTTP status code 401 (Unauthorized) instead of 403 (Forbidden) now.
+- Breaking change: Removed whitelist. To retain similar functionality, install a separate plugin, such as https://wordpress.org/plugins/disable-rest-api-and-require-jwt-oauth-authentication/
 
 = 2.1.0 =
 - It's possible now to whitelist an endpoint with specific method (GET/POST). See [PR #47](https://github.com/usefulteam/jwt-auth/pull/47)


### PR DESCRIPTION
Resolves #56 

Problem
- The plugin currently intercepts REST API requests to other endpoints when the client could not be authenticated by JWT.  This causes many conflicts with other plugins:
     - https://github.com/usefulteam/jwt-auth/issues?q=is%3Aissue+is%3Aopen+whitelist
     - https://wordpress.org/support/plugin/jwt-auth/

Details
- It is not clear why the whitelist functionality is included in the plugin. Based on the code, it seems to be an attempt to require JWT authentication for all REST API endpoints and not allow anonymous requests or other means of authentication anymore.
- It seems the whitelist predates wider use of the REST API in the WordPress ecosystem as well as the built-in application passwords in WordPress Core. More endpoints are using an authentication (but not JWT) today.

Proposed solution
1. Remove the whitelist.
2. Point users to existing plugins offering the same or similar functionality, in case anyone needs it; e.g.:
    - https://wordpress.org/plugins/disable-rest-api-and-require-jwt-oauth-authentication/