### PR TITLE
'Authentication failed' message converted in plain text

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -183,7 +183,7 @@ class Auth {
 					'success'    => false,
 					'statusCode' => 401,
 					'code'       => $error_code,
-					'message'    => strip_tags( $user->get_error_message( $error_code ) ),
+					'message'    => strip_tags('Authentication failed: '.$error_code),
 					'data'       => array(),
 				),
 				401


### PR DESCRIPTION
A failed authentication on /token no more returns an HTML message.

Before this commit, the /token endopoint was returning thw Wordpress default error for a failed login. This was an HTML string with a link to recover the password.

Dealing with REST API it's better to always have plain text as a message