### PR TITLE
Slash password before authenticating

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -128,7 +128,7 @@ class Auth {
 			 */
 			$user = apply_filters( 'jwt_auth_do_custom_auth', $custom_auth_error, $username, $password, $custom_auth );
 		} else {
-			$user = wp_authenticate( $username, $password );
+			$user = wp_authenticate($username, wp_slash($password));
 		}
 
 		return $user;


### PR DESCRIPTION
Fixes erroneous 403 response when a password contains a single quote.

When attempting to authenticate with a (correct) password containing quotes, the API returns "403 Forbidden":
{ "code": "[jwt_auth] incorrect_password", "message": "...", "data": { "status": 403 } }

Using wp_slash (https://developer.wordpress.org/reference/functions/wp_slash/) to make sure the password is handled correctly.