### PR TITLE
Add environment variable support

### DIFF
--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -29,4 +29,14 @@ require __DIR__ . '/class-auth.php';
 require __DIR__ . '/class-setup.php';
 require __DIR__ . '/class-devices.php';
 
+// Register JWT constants from environment variables
+$jwt_env_vars = array(
+    'JWT_AUTH_SECRET_KEY' => '',
+    'JWT_AUTH_CORS_ENABLE' => false
+);
+
+foreach($jwt_env_vars as $key => $default) {
+    defined($key) or define($key, getenv($key) ?? $default);
+}
+
 JWTAuth\Setup::getInstance();


### PR DESCRIPTION
The JWT_AUTH_SECRET_KEY as well as JWT_AUTH_CORS_ENABLE can be read from environment variables instead of hardcoding in wp-config.php