### PR TITLE
Do not validate authentication headers if a valid user was determined already.

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -606,7 +606,8 @@ class Auth {
 
 		$valid_api_uri = strpos( $_SERVER['REQUEST_URI'], $this->rest_api_slug );
 
-		if ( ! $valid_api_uri ) {
+		// if already valid user or invalid url, don't attempt to validate token
+		if ( ! $valid_api_uri || $user_id ) {
 			return $user_id;
 		}
 

--- a/class-auth.php
+++ b/class-auth.php
@@ -606,7 +606,7 @@ class Auth {
 
 		$valid_api_uri = strpos( $_SERVER['REQUEST_URI'], $this->rest_api_slug );
 
-		// if already valid user or invalid url, don't attempt to validate token
+		// Skip validation if not a REST API request or a user was determined already.
 		if ( ! $valid_api_uri || $user_id ) {
 			return $user_id;
 		}


### PR DESCRIPTION
Allow for Basic Auth, by not attempting to validate Authentication Headers if a valid user has already been determined.