### PR TITLE
Fixed refresh token validation error message covers too many cases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,42 @@ If the token is invalid an error will be returned. Here are some samples of erro
 }
 ```
 
+**Invalid Refresh Token**
+
+```json
+{
+	"success": false,
+	"statusCode": 401,
+	"code": "jwt_auth_invalid_refresh_token",
+	"message": "Invalid refresh token",
+	"data": []
+}
+```
+
+**Obsolete Refresh Token**
+
+```json
+{
+	"success": false,
+	"statusCode": 401,
+	"code": "jwt_auth_obsolete_refresh_token",
+	"message": "Refresh token is obsolete",
+	"data": []
+}
+```
+
+**Expired Refresh Token**
+
+```json
+{
+	"success": false,
+	"statusCode": 401,
+	"code": "jwt_auth_expired_refresh_token",
+	"message": "Refresh token has expired",
+	"data": []
+}
+```
+
 ## Available Filter Hooks
 
 **JWT Auth** is developer friendly and has some filters available to override the default settings.

--- a/class-auth.php
+++ b/class-auth.php
@@ -581,7 +581,7 @@ class Auth {
 				),
 				401
 			);
-		} elseif ( $user_refresh_tokens[ $device ]['token'] !== $refresh_token ) {
+		} elseif ( $refresh_token !== $user_refresh_tokens[ $device ]['token'] ) {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,

--- a/class-auth.php
+++ b/class-auth.php
@@ -571,16 +571,33 @@ class Auth {
 		$user_refresh_tokens = get_user_meta( $user_id, 'jwt_auth_refresh_tokens', true );
 		$refresh_token       = $parts[1];
 
-		if ( empty( $user_refresh_tokens[ $device ] ) ||
-			$user_refresh_tokens[ $device ]['token'] !== $refresh_token ||
-			$user_refresh_tokens[ $device ]['expires'] < time()
-			) {
+		if ( empty( $user_refresh_tokens[ $device ] ) ) {
 			return new WP_REST_Response(
 				array(
 					'success'    => false,
 					'statusCode' => 401,
-					'code'       => 'jwt_auth_obsolete_token',
-					'message'    => __( 'Token is obsolete', 'jwt-auth' ),
+					'code'       => 'jwt_auth_invalid_refresh_token',
+					'message'    => __( 'Invalid refresh token', 'jwt-auth' ),
+				),
+				401
+			);
+		} elseif ( $user_refresh_tokens[ $device ]['token'] !== $refresh_token ) {
+			return new WP_REST_Response(
+				array(
+					'success'    => false,
+					'statusCode' => 401,
+					'code'       => 'jwt_auth_obsolete_refresh_token',
+					'message'    => __( 'Refresh token is obsolete', 'jwt-auth' ),
+				),
+				401
+			);
+		} elseif ( time() > $user_refresh_tokens[ $device ]['expires'] ) {
+			return new WP_REST_Response(
+				array(
+					'success'    => false,
+					'statusCode' => 401,
+					'code'       => 'jwt_auth_expired_refresh_token',
+					'message'    => __( 'Refresh token has expired', 'jwt-auth' ),
 				),
 				401
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -359,6 +359,42 @@ If the token is invalid an error will be returned. Here are some samples of erro
 }
 `
 
+= Invalid Refresh Token =
+
+`
+{
+	"success": false,
+	"statusCode": 401,
+	"code": "jwt_auth_invalid_refresh_token",
+	"message": "Invalid refresh token",
+	"data": []
+}
+`
+
+= Obsolete Refresh Token =
+
+`
+{
+	"success": false,
+	"statusCode": 401,
+	"code": "jwt_auth_obsolete_refresh_token",
+	"message": "Refresh token is obsolete",
+	"data": []
+}
+`
+
+= Expired Refresh Token =
+
+`
+{
+	"success": false,
+	"statusCode": 401,
+	"code": "jwt_auth_expired_refresh_token",
+	"message": "Refresh token has expired",
+	"data": []
+}
+`
+
 ## Available Filter Hooks
 
 **JWT Auth** is developer friendly and has some filters available to override the default settings.


### PR DESCRIPTION
Problem
- The error message returned by the refresh token validation does not indicate why the refresh token is obsolete.

Details
- On our site, one of the mobile apps receives an error response when trying to regenerate the refresh token.
- We want to learn into which exact validation case the app runs into.

Proposed solution
1. Return a different error response for each of the validation cases.

Remaining Todos

- [x] Document the new codes in the readme files
- [x] Update .pot file — Skipping this because the .pot file is empty/malformed