### PR TITLE
Add update warning

### DIFF
--- a/class-plugin-update.php
+++ b/class-plugin-update.php
@@ -18,6 +18,8 @@ class Plugin_Updates {
    */
   public function __construct() {
     add_action( 'in_plugin_update_message-jwt-auth/jwt-auth.php' , array( $this , 'display_update_warnings' ) , 10 , 2 );
+		add_action( 'admin_notices' , array( $this , 'display_future_update_warning' ) );
+		add_action( 'admin_init', array( 'PAnD', 'init' ) );
   }
 
 	/**
@@ -58,4 +60,25 @@ class Plugin_Updates {
 		echo $output;
 
 	}
+
+  public function display_future_update_warning() {
+
+    if ( ! \PAnD::is_admin_notice_active( 'jwt-v3-update-warning-1' ) ) {
+      return;
+    }
+
+    ob_start(); ?>
+
+    <div data-dismissible="jwt-v3-update-warning-1" class="updated notice notice-warning is-dismissible">
+			<div style="font-weight: normal; overflow:auto">
+				<p><?php echo __( 'Important! An upcoming version of the JWT Auth plugin contains major new features that will change the behaviour of your site.', 'jwt-auth' ); ?>
+					<?php echo __( 'More information can be found on <a href="https://wordpress.org/plugins/jwt-auth/" target="_blank">the plugin page on WordPress.org</a>.', 'jwt-auth' ); ?></p>
+			</div>
+    </div>
+
+    <?php
+    $output = ob_get_clean();
+    echo $output;
+
+  }
 }

--- a/class-plugin-update.php
+++ b/class-plugin-update.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * JWT-Auth Plugin Updates Class.
+ *
+ * @package jwt-auth
+ */
+
+namespace JWTAuth;
+
+/**
+ * Manage activities related to plugin updates.
+ * Added by Dominic Vermeulen-Smith https://github.com/dominic-ks
+ */
+class Plugin_Updates {
+
+  /**
+   * Setup action & filter hooks.
+   */
+  public function __construct() {
+    add_action( 'in_plugin_update_message-jwt-auth/jwt-auth.php' , array( $this , 'display_update_warnings' ) , 10 , 2 );
+  }
+
+	/**
+	 * Display update warnings for users updating from 2.x to 3.x.
+	 * 
+	 * @param array $plugin_data Plugin data.
+	 * @param array $response Response.
+	 */
+	public function display_update_warnings( $plugin_data , $response ) {
+
+		$new_version = explode( '.' , $plugin_data['new_version'] );
+		$old_version = explode( '.' , $plugin_data['Version'] );
+
+    // Only display warning if updating from 2.x to 3.x.
+		if( intval( $old_version[0] ) >= 3 || intval( $new_version[0] ) < 3 ) {
+			return;
+		}
+
+		ob_start(); ?>
+
+		<style>
+			.wrap .notice p:last-of-type::before {
+				display: none;
+			}
+		</style>
+
+		<div style="color: #f00;"><?php echo __( 'IMPORTANT! Please read before updating:', 'jwt-auth' ); ?></div>
+		<div style="font-weight: normal; overflow:auto">
+			<?php echo __( 'V' . $plugin_data['new_version'] . ' of the JWT Auth plugin contains major new features that will change the behaviour of your site.', 'jwt-auth' ); ?> 
+			<?php echo __( 'Please review the details of the new version before updating.', 'jwt-auth' ); ?> 
+			<br /><br />
+			<?php echo __( 'More information can be found on <a href="https://wordpress.org/plugins/jwt-auth/" target="_blank">the plugin page on WordPress.org</a>.', 'jwt-auth' ); ?>
+			<div style="clear: left;"></div>
+		</div>
+
+		<?php
+		$output = ob_get_clean();
+		echo $output;
+
+	}
+}

--- a/class-setup.php
+++ b/class-setup.php
@@ -15,6 +15,7 @@ class Setup {
 	private static $instance;
 	public $auth;
 	public $devices;
+	public $updates;
 
 	/**
 	 * Constructs singleton.
@@ -39,6 +40,12 @@ class Setup {
 		add_filter( 'rest_api_init', array( $this->auth, 'add_cors_support' ) );
 		add_filter( 'rest_pre_dispatch', array( $this->auth, 'rest_pre_dispatch' ), 10, 3 );
 		add_filter( 'determine_current_user', array( $this->auth, 'determine_current_user' ) );
+
+		// add plugin updates class and filters only in wp-admin
+		if ( is_admin() ) {
+			$this->updates = new Plugin_Updates();
+		}
+
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "firebase/php-jwt": "^6.3"
+        "firebase/php-jwt": "^6.3",
+        "collizo4sky/persist-admin-notices-dismissal": "^1.4"
     }
 }

--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -28,5 +28,6 @@ require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/class-auth.php';
 require __DIR__ . '/class-setup.php';
 require __DIR__ . '/class-devices.php';
+require __DIR__ . '/class-plugin-update.php';
 
 new JWTAuth\Setup();

--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ WordPress JSON Web Token Authentication allows you to do REST API authentication
 - [Discord channel](https://discord.gg/DgECpEg) also available for faster response.
 
 ## IMPORTANT INFORMATION FOR V3.x+
-The latest version of this plugin will soon be released on the WordPress.org plugin repo.
+[The latest version](https://github.com/usefulteam/jwt-auth/) of this plugin will soon be released on the WordPress.org plugin repo.
 
 If you are updating from V2.x to V3.x you should familiarise yourself with the upcoming changes to ensure that your site continues to work as you expect it to.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.me/bagusjavas
 Tags: jwt, jwt-auth, token-authentication, json-web-token
 Requires at least: 5.2
 Tested up to: 6.1
-Stable tag: 2.1.2
+Stable tag: 2.1.4
 Requires PHP: 7.2
 License: GPLv3
 License URI: https://oss.ninja/gpl-3.0?organization=Useful%20Team&project=WordPress%20JWT%20Auth
@@ -18,6 +18,32 @@ WordPress JSON Web Token Authentication allows you to do REST API authentication
 - Support & question: [WordPress support forum](https://wordpress.org/support/plugin/jwt-auth/)
 - Reporting plugin's bug: [GitHub issues tracker](https://github.com/usefulteam/jwt-auth/issues)
 - [Discord channel](https://discord.gg/DgECpEg) also available for faster response.
+
+## IMPORTANT INFORMATION FOR V3.x+
+The latest version of this plugin will soon be released on the WordPress.org plugin repo.
+
+If you are updating from V2.x to V3.x you should familiarise yourself with the upcoming changes to ensure that your site continues to work as you expect it to.
+
+There are two imoportant changes:
+
+= Introduction of refresh tokens =
+
+[See this section of the readme on GitHub](https://github.com/usefulteam/jwt-auth#refreshing-the-access-token)
+
+Key changes:
+
+- Default JWT expiry time will reduce from 7 days to 10 minutes.
+- On expiry of a JWT, your client will need to manage getting a new token using the [refresh token process described here](https://github.com/usefulteam/jwt-auth#refreshing-the-access-token).
+- If you would prefer to retain the 7 day expiry time initially or permanently, you can use the `jwt_auth_expire` hook as documented on this page to force the expiry time to remain at 7 days.
+
+= Removal of the URL whitelist and related filter =
+
+Key changes:
+
+- Users of this plugin will no longer need to whitelist the REST paths from other plugins using the  `jwt_auth_whitelist` as documented on this page.
+- Instead, custom API routes should have the permissions requirement coded via the [permissions callback](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback) of the REST API route when it is registered.
+- This means that if a route requires authentication, any authentication method can be used and should reduce conflicts between this and other plugins.
+- For further information please see [this discussion](https://github.com/usefulteam/jwt-auth/pull/60) on GitHub.
 
 ## Enable PHP HTTP Authorization Header
 
@@ -707,6 +733,15 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 3. Other error responses
 
 == Changelog ==
+= 2.1.4 =
+- Added update warning and information relevant to updating to version 3.x+
+
+= 2.1.3 =
+- Fix some missing composer files in 2.1.2.
+
+= 2.1.2 =
+- Updated to fix a number of issues highlighted by wpcs.
+
 = 2.1.1 =
 - Updated firebase/php-jwt to 6.3 to address security issue in versions prior to 6.x.
 


### PR DESCRIPTION
This PR adds two warnings to a new version of the plugin - 2.1.4 - intended to go to WordPress.org users so that they are warned of upcoming changes in version 3.x+ before they are released to the WordPress.org plugin repo.

This warning will be displayed in wp-admin and is permanently dismissible (the [collizo4sky/persist-admin-notices-dismissal](https://github.com/w3guy/persist-admin-notices-dismissal) lib was added to manage persisting the dismissal):

![jwt-plugin-warning-2](https://user-images.githubusercontent.com/8981714/209700305-869b3ff8-5753-4554-95f3-7351588ab059.jpg)

When a user currently has a version lower than 3.x and an update to a version of 3.x this warning will be displayed (quoting the relevant update version):

![jwt-plugin-warning](https://user-images.githubusercontent.com/8981714/209700294-8e18836d-6477-4615-b973-0c2274afbfc5.jpg)

Added details to the WordPress.org plugin readme to help users understand the changes.
