### PR TITLE
add samesite attribute to refresh_token cookie

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -275,7 +275,16 @@ class Auth {
 		$expires       = $created + DAY_IN_SECONDS * 30;
 		$expires       = apply_filters( 'jwt_auth_refresh_expire', $expires, $created );
 
-		setcookie( 'refresh_token', $user->ID . '.' . $refresh_token, $expires, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+		$enable_cors = defined( 'JWT_AUTH_CORS_ENABLE' ) ? JWT_AUTH_CORS_ENABLE : false;
+
+		setcookie( 'refresh_token', $user->ID . '.' . $refresh_token, [
+			'expires'  => $expires,
+			'path'     => COOKIEPATH,
+			'domain'   => COOKIE_DOMAIN,
+			'secure'   => is_ssl(),
+			'httponly' => true,
+			'samesite' => ( $enable_cors && is_ssl() ) ? 'None' : 'Lax'
+		] );
 
 		// Save new refresh token for the user, replacing the previous one.
 		// The refresh token is rotated for the passed device only, not affecting


### PR DESCRIPTION
Chrome prohibits the refresh_token cookie from being set from cross-origin requests because it is missing the samesite attribute. 

Things to consider:
- This syntax requires a minimum PHP version of 7.3. Do we need a version check or workaround here to support a lower version?
- The default for samesite would be `Lax` maybe this could even be set to `Strict` as the refresh_token is probably only used on subsequent requests in a first-party context when not cross-origin.