### PR TITLE
Prioritise authentication with user credentials over refresh token if both are sent.

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -489,7 +489,7 @@ class Auth {
 						'success'    => false,
 						'statusCode' => 401,
 						'code'       => 'jwt_auth_invalid_token',
-						'message'    => __( "Expired token", 'jwt-auth' ),
+						'message'    => __( "Invalid token", 'jwt-auth' ),
 						'data'       => array(),
 					),
 					401

--- a/class-auth.php
+++ b/class-auth.php
@@ -178,7 +178,31 @@ class Auth {
 			);
 		}
 
-		if ( isset( $_COOKIE['refresh_token'] ) ) {
+		if ( isset( $username ) && ! isset( $password )) {
+			$user = new WP_Error(
+				'jwt_auth_no_password',
+				__( 'Password is required', 'jwt-auth' ),
+				array(
+					'status' => 400,
+				)
+			);
+		}
+
+		if ( isset( $password ) && ! isset( $username )) {
+			$user = new WP_Error(
+				'jwt_auth_no_username',
+				__( 'Username is required', 'jwt-auth' ),
+				array(
+					'status' => 400,
+				)
+			);
+		}
+
+		if ( isset( $password ) && isset( $username )) {
+			$user = $this->authenticate_user( $username, $password, $custom_auth );
+		}
+
+		if ( ! $username && ! $password && isset( $_COOKIE['refresh_token'] ) ) {
 			$device  = $request->get_param( 'device' ) ?: '';
 			$user_id = $this->validate_refresh_token( $_COOKIE['refresh_token'], $device );
 
@@ -187,8 +211,6 @@ class Auth {
 				return $user_id;
 			}
 			$user = get_user_by( 'id', $user_id );
-		} else {
-			$user = $this->authenticate_user( $username, $password, $custom_auth );
 		}
 
 		// If the authentication is failed return error response.

--- a/class-auth.php
+++ b/class-auth.php
@@ -202,6 +202,16 @@ class Auth {
 				return $user_id;
 			}
 			$user = get_user_by( 'id', $user_id );
+
+			if ( ! $user ) {
+				$user = new WP_Error(
+					'jwt_auth_user_not_found',
+					__( 'User not found', 'jwt-auth' ),
+					array(
+						'status' => 401,
+					)
+				);
+			}
 		}
 
 		// If the authentication is failed return error response.

--- a/class-auth.php
+++ b/class-auth.php
@@ -178,27 +178,18 @@ class Auth {
 			);
 		}
 
-		if ( isset( $username ) && ! isset( $password )) {
+		if ( ( isset( $username ) && ! isset( $password ) )
+		     ( ! isset( $username ) && isset( $password ) ) ) {
 			$user = new WP_Error(
-				'jwt_auth_no_password',
-				__( 'Password is required', 'jwt-auth' ),
+				'jwt_auth_missing_credentials',
+				__( 'Username and password are required', 'jwt-auth' ),
 				array(
 					'status' => 400,
 				)
 			);
 		}
 
-		if ( isset( $password ) && ! isset( $username )) {
-			$user = new WP_Error(
-				'jwt_auth_no_username',
-				__( 'Username is required', 'jwt-auth' ),
-				array(
-					'status' => 400,
-				)
-			);
-		}
-
-		if ( isset( $password ) && isset( $username )) {
+		if ( isset( $username ) && isset( $password ) ) {
 			$user = $this->authenticate_user( $username, $password, $custom_auth );
 		}
 

--- a/class-auth.php
+++ b/class-auth.php
@@ -192,8 +192,7 @@ class Auth {
 		if ( isset( $username ) && isset( $password ) ) {
 			$user = $this->authenticate_user( $username, $password, $custom_auth );
 		}
-
-		if ( ! $username && ! $password && isset( $_COOKIE['refresh_token'] ) ) {
+		elseif ( isset( $_COOKIE['refresh_token'] ) ) {
 			$device  = $request->get_param( 'device' ) ?: '';
 			$user_id = $this->validate_refresh_token( $_COOKIE['refresh_token'], $device );
 

--- a/class-auth.php
+++ b/class-auth.php
@@ -205,8 +205,8 @@ class Auth {
 
 			if ( ! $user ) {
 				$user = new WP_Error(
-					'jwt_auth_user_not_found',
-					__( 'User not found', 'jwt-auth' ),
+					'jwt_auth_invalid_refresh_token',
+					__( 'Invalid refresh token', 'jwt-auth' ),
 					array(
 						'status' => 401,
 					)
@@ -488,8 +488,8 @@ class Auth {
 					array(
 						'success'    => false,
 						'statusCode' => 401,
-						'code'       => 'jwt_auth_user_not_found',
-						'message'    => __( "User doesn't exist", 'jwt-auth' ),
+						'code'       => 'jwt_auth_invalid_token',
+						'message'    => __( "Expired token", 'jwt-auth' ),
 						'data'       => array(),
 					),
 					401

--- a/class-auth.php
+++ b/class-auth.php
@@ -179,7 +179,8 @@ class Auth {
 		}
 
 		if ( ( isset( $username ) && ! isset( $password ) )
-		     ( ! isset( $username ) && isset( $password ) ) ) {
+			|| ( ! isset( $username ) && isset( $password ) ) 
+			|| ! isset( $_COOKIE['refresh_token'] ) ) {
 			$user = new WP_Error(
 				'jwt_auth_missing_credentials',
 				__( 'Username and password are required', 'jwt-auth' ),

--- a/readme.txt
+++ b/readme.txt
@@ -803,6 +803,9 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 3. Other error responses
 
 == Changelog ==
+= 3.0.x =
+- Ensure that new logins are prioritised over refresh tokens when both are present.
+
 = 3.0.2 =
 - Fix: Do not revalidate authentication headers if a valid user was determined already. (#75)
 - Fix: Added debugging timeframe before purging refresh tokens. (#93)

--- a/readme.txt
+++ b/readme.txt
@@ -804,7 +804,7 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 
 == Changelog ==
 = 3.0.x =
-- Ensure that new logins are prioritised over refresh tokens when both are present.
+- Prioritise authentication with user credentials over refresh token if both are sent.
 
 = 3.0.2 =
 - Fix: Do not revalidate authentication headers if a valid user was determined already. (#75)

--- a/readme.txt
+++ b/readme.txt
@@ -816,7 +816,7 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 
 == Changelog ==
 = 3.0.x =
-- Prioritise authentication with user credentials over refresh token if both are sent.
+- Fix: Prioritise authentication with user credentials over refresh token if both are sent.
 
 = 3.0.2 =
 - Fix: Do not revalidate authentication headers if a valid user was determined already. (#75)

--- a/readme.txt
+++ b/readme.txt
@@ -296,6 +296,18 @@ If the token is invalid an error will be returned. Here are some samples of erro
 }
 `
 
+= Missing Username and / or Password or Refresh Token =
+
+`
+{
+	"success": false,
+	"statusCode": 400,
+	"code": "jwt_auth_missing_credentials",
+	"message": "Username and password are required",
+	"data": []
+}
+`
+
 = User Not Found =
 
 `


### PR DESCRIPTION
Addressing the issue reported here:

 - [https://github.com/usefulteam/jwt-auth/issues/127](https://github.com/usefulteam/jwt-auth/issues/127)

I also added some checks so that we can handle cases where a username is provided and no password or vice versa so that we don't log someone in based on a refresh token purely because an invalid request has been made.