### PR TITLE
updated version tags

### DIFF
--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -3,7 +3,7 @@
  * Plugin Name: JWT Auth
  * Plugin URI:  https://github.com/usefulteam/jwt-auth
  * Description: WordPress JWT Authentication.
- * Version:     3.0.2
+ * Version:     3.0.3
  * Author:      Useful Team
  * Author URI:  https://usefulteam.com
  * License:     GPL-3.0

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: contactjavas, tha_sun, dominic_ks
 Tags: jwt, jwt-auth, token-authentication, json-web-token
 Requires at least: 5.2
 Tested up to: 6.5.3
-Stable tag: 3.0.2
+Stable tag: 3.0.3
 Requires PHP: 7.2
 License: GPLv3
 License URI: https://oss.ninja/gpl-3.0?organization=Useful%20Team&project=WordPress%20JWT%20Auth
@@ -815,7 +815,7 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 3. Other error responses
 
 == Changelog ==
-= 3.0.x =
+= 3.0.3 =
 - Fix: Prioritise authentication with user credentials over refresh token if both are sent.
 
 = 3.0.2 =


### PR DESCRIPTION
@sun as was mentioned [here](https://github.com/usefulteam/jwt-auth/issues/127#issuecomment-2428153035), yes, it'd be good to release this. I guess we don't have a process for releasing, if you have any thoughts, please say, otherwise, I'm just putting this pull request in to update the version tags and if we agree, and it's approved then whoever merges can also just tag the release which will trigger it to go to wp.org. Happy with that?