### PR TITLE
Fixed string translation is invoked before gettext domain is registered.

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -36,13 +36,6 @@ class Auth {
 	private $jwt_error = null;
 
 	/**
-	 * Collection of translate-able messages.
-	 *
-	 * @var array
-	 */
-	private $messages = array();
-
-	/**
 	 * The REST API slug.
 	 *
 	 * @var string
@@ -54,11 +47,6 @@ class Auth {
 	 */
 	public function __construct() {
 		$this->namespace = 'jwt-auth/v1';
-
-		$this->messages = array(
-			'jwt_auth_no_auth_header'  => __( 'Authorization header not found.', 'jwt-auth' ),
-			'jwt_auth_bad_auth_header' => __( 'Authorization header malformed.', 'jwt-auth' ),
-		);
 	}
 
 	/**
@@ -402,7 +390,7 @@ class Auth {
 					'success'    => false,
 					'statusCode' => 401,
 					'code'       => 'jwt_auth_no_auth_header',
-					'message'    => $this->messages['jwt_auth_no_auth_header'],
+					'message'    => __( 'Authorization header not found.', 'jwt-auth' ),
 					'data'       => array(),
 				),
 				401
@@ -421,7 +409,7 @@ class Auth {
 					'success'    => false,
 					'statusCode' => 401,
 					'code'       => 'jwt_auth_bad_auth_header',
-					'message'    => $this->messages['jwt_auth_bad_auth_header'],
+					'message'    => __( 'Authorization header malformed.', 'jwt-auth' ),
 					'data'       => array(),
 				),
 				401

--- a/class-setup.php
+++ b/class-setup.php
@@ -58,7 +58,7 @@ class Setup {
 	 * Setup textdomain.
 	 */
 	public function setup_text_domain() {
-		load_plugin_textdomain( 'jwt-auth', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
+		load_plugin_textdomain( 'jwt-auth', false, plugin_basename( __DIR__ ) . '/languages' );
 	}
 
 	/**


### PR DESCRIPTION
Problem
- With `WP_DEBUG` enabled, WordPress logs the following message for every request/bootstrap:
> Notice: Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>jwt-auth</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /wp-includes/functions.php on line 6121

Cause
- It wasn't obvious what triggered it, because the plugin loads the gettext domain normally in the init hook.
- Only when forcibly throwing an exception in `wp_trigger_error()` and checking the stack trace, the cause becomes clear — the plugin tries to translate some strings too early, directly when the code is loaded, before the gettext domain is even registered:
```
Stack trace:
#0 /wp-includes/functions.php(6061): wp_trigger_error('', 'Function _load_...')
#1 /wp-includes/l10n.php(1371): _doing_it_wrong('_load_textdomai...', 'Function _load_...', '(This message w...')
#2 /wp-includes/l10n.php(1409): _load_textdomain_just_in_time('jwt-auth')
#3 /wp-includes/l10n.php(195): get_translations_for_domain('jwt-auth')
#4 /wp-includes/l10n.php(307): translate('Authorization h...', 'jwt-auth')
#5 /wp-content/plugins/jwt-auth/class-auth.php(59): __('Authorization h...', 'jwt-auth')  <-- HERE
#6 /wp-content/plugins/jwt-auth/class-setup.php(36): JWTAuth\Auth->__construct()
#7 /wp-content/plugins/jwt-auth/class-setup.php(25): JWTAuth\Setup->__construct()
#8 /wp-content/plugins/jwt-auth/jwt-auth.php(32): JWTAuth\Setup::getInstance()
#9 /wp-settings.php(545): include_once('/site...')
#10 phar:///bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1375): require('/site...')
#11 phar:///bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1294): WP_CLI\Runner->load_wordpress()
#12 phar:///bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#13 phar:///bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#14 phar:///bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
#15 phar:///bin/wp/php/boot-phar.php(20): include('phar:///Users/s...')
#16 /bin/wp(4): include('phar:///Users/s...')
#17 {main}
```

Proposed solution
1. The early translation and collection of translatable strings is completely unnecessary and can be dissolved.
    
    In fact, fixing this is even a micro performance optimization, because
    - multiple strings were translated whereas only one will be needed
    - none of the strings nor their translations will be needed if there is no error

Compatibility
- The `$messages` property was private, so not accessible from elsewhere; not even child classes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210409185753116