### PR TITLE
Fixed infinite recursion in determine_current_user caused by get_user_locale().

### DIFF
--- a/class-auth.php
+++ b/class-auth.php
@@ -480,8 +480,8 @@ class Auth {
 					array(
 						'success'    => false,
 						'statusCode' => 401,
-						'code'       => 'jwt_auth_user_not_found',
-						'message'    => $has_l10n ? __( "User doesn't exist", 'jwt-auth' ) : "User doesn't exist",
+						'code'       => 'jwt_auth_invalid_token',
+						'message'    => $has_l10n ? __( "Invalid token", 'jwt-auth' ) : "Invalid token",
 						'data'       => array(),
 					),
 					401

--- a/class-auth.php
+++ b/class-auth.php
@@ -374,7 +374,7 @@ class Auth {
 	public function validate_token( $return_response = true ) {
 		global $l10n;
 
-		$has_l10n = isset( $l10n[ 'jwt_auth' ] );
+		$has_l10n = isset( $l10n[ 'jwt-auth' ] );
 
 		/**
 		 * Looking for the HTTP_AUTHORIZATION header, if not present just

--- a/class-auth.php
+++ b/class-auth.php
@@ -372,6 +372,10 @@ class Auth {
 	 * @return WP_REST_Response | Array Returns WP_REST_Response or token's $payload.
 	 */
 	public function validate_token( $return_response = true ) {
+		global $l10n;
+
+		$has_l10n = isset( $l10n[ 'jwt_auth' ] );
+
 		/**
 		 * Looking for the HTTP_AUTHORIZATION header, if not present just
 		 * return the user.
@@ -390,7 +394,7 @@ class Auth {
 					'success'    => false,
 					'statusCode' => 401,
 					'code'       => 'jwt_auth_no_auth_header',
-					'message'    => __( 'Authorization header not found.', 'jwt-auth' ),
+					'message'    => $has_l10n ? __( 'Authorization header not found.', 'jwt-auth' ) : 'Authorization header not found.',
 					'data'       => array(),
 				),
 				401
@@ -409,7 +413,7 @@ class Auth {
 					'success'    => false,
 					'statusCode' => 401,
 					'code'       => 'jwt_auth_bad_auth_header',
-					'message'    => __( 'Authorization header malformed.', 'jwt-auth' ),
+					'message'    => $has_l10n ? __( 'Authorization header malformed.', 'jwt-auth' ) : 'Authorization header malformed.',
 					'data'       => array(),
 				),
 				401
@@ -425,7 +429,7 @@ class Auth {
 					'success'    => false,
 					'statusCode' => 401,
 					'code'       => 'jwt_auth_bad_config',
-					'message'    => __( 'JWT is not configured properly.', 'jwt-auth' ),
+					'message'    => $has_l10n ? __( 'JWT is not configured properly.', 'jwt-auth' ) : 'JWT is not configured properly.',
 					'data'       => array(),
 				),
 				401
@@ -445,7 +449,7 @@ class Auth {
 						'success'    => false,
 						'statusCode' => 401,
 						'code'       => 'jwt_auth_bad_iss',
-						'message'    => __( 'The iss do not match with this server.', 'jwt-auth' ),
+						'message'    => $has_l10n ? __( 'The iss do not match with this server.', 'jwt-auth' ) : 'The iss do not match with this server.',
 						'data'       => array(),
 					),
 					401
@@ -460,7 +464,7 @@ class Auth {
 						'success'    => false,
 						'statusCode' => 401,
 						'code'       => 'jwt_auth_bad_request',
-						'message'    => __( 'User ID not found in the token.', 'jwt-auth' ),
+						'message'    => $has_l10n ? __( 'User ID not found in the token.', 'jwt-auth' ) : 'User ID not found in the token.',
 						'data'       => array(),
 					),
 					401
@@ -476,8 +480,8 @@ class Auth {
 					array(
 						'success'    => false,
 						'statusCode' => 401,
-						'code'       => 'jwt_auth_invalid_token',
-						'message'    => __( "Invalid token", 'jwt-auth' ),
+						'code'       => 'jwt_auth_user_not_found',
+						'message'    => $has_l10n ? __( "User doesn't exist", 'jwt-auth' ) : "User doesn't exist",
 						'data'       => array(),
 					),
 					401
@@ -494,7 +498,7 @@ class Auth {
 						'success'    => false,
 						'statusCode' => 401,
 						'code'       => 'jwt_auth_obsolete_token',
-						'message'    => __( 'Token is obsolete', 'jwt-auth' ),
+						'message'    => $has_l10n ? __( 'Token is obsolete', 'jwt-auth' ) : 'Token is obsolete',
 						'data'       => array(),
 					),
 					401
@@ -510,7 +514,7 @@ class Auth {
 				'success'    => true,
 				'statusCode' => 200,
 				'code'       => 'jwt_auth_valid_token',
-				'message'    => __( 'Token is valid', 'jwt-auth' ),
+				'message'    => $has_l10n ? __( 'Token is valid', 'jwt-auth' ) : 'Token is valid',
 				'data'       => array(),
 			);
 

--- a/readme.txt
+++ b/readme.txt
@@ -816,7 +816,7 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 
 == Changelog ==
 = 3.0.x =
-- Fix: Gettext string translation is invoked before gettext domain is loaded.
+- Fix: String translation is invoked before gettext domain is loaded.
 - Fix: Prioritise authentication with user credentials over refresh token if both are sent.
 
 = 3.0.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -816,6 +816,7 @@ You can help this plugin stay alive and maintained by giving **5 Stars** Rating/
 
 == Changelog ==
 = 3.0.x =
+- Fix: Gettext string translation is invoked before gettext domain is loaded.
 - Fix: Prioritise authentication with user credentials over refresh token if both are sent.
 
 = 3.0.2 =


### PR DESCRIPTION
Context
- #139

Problem
- As detailed in https://github.com/usefulteam/jwt-auth/pull/139#issuecomment-3143943336, `get_user_locale()` causes an infinite recursion to hook `determine_current_user` if the request contains the query parameter `?_locale=user`.

Stack trace
```
#0 /wp-includes/class-wp-hook.php(324): wp_validate_auth_cookie(false)
#1 /wp-includes/plugin.php(205): WP_Hook->apply_filters(false, Array)
#2 /wp-includes/user.php(3753): apply_filters('determine_curre...', false)
#3 /wp-includes/pluggable.php(70): _wp_get_current_user()
#4 /wp-includes/l10n.php(98): wp_get_current_user()
#5 /wp-includes/l10n.php(153): get_user_locale()
#6 /wp-includes/l10n.php(1364): determine_locale()
#7 /wp-includes/l10n.php(1409): _load_textdomain_just_in_time('jwt-auth')
#8 /wp-includes/l10n.php(195): get_translations_for_domain('jwt-auth')
#9 /wp-includes/l10n.php(307): translate('Authorization h...', 'jwt-auth')
#10 /wp-content/plugins/jwt-auth/class-auth.php(370): __('Authorization h...', 'jwt-auth')
#11 /wp-content/plugins/jwt-auth/class-auth.php(650): JWTAuth\Auth->validate_token(false)
#12 /wp-includes/class-wp-hook.php(324): JWTAuth\Auth->determine_current_user(false)
#13 /wp-includes/plugin.php(205): WP_Hook->apply_filters(false, Array)
#14 /wp-includes/user.php(3753): apply_filters('determine_curre...', false)
#15 /wp-includes/pluggable.php(70): _wp_get_current_user()
#16 /wp-includes/capabilities.php(911): wp_get_current_user()
#17 /wp-content/plugins/enable-media-replace/classes/emr-plugin.php(46): current_user_can('upload_files')
#18 /wp-includes/class-wp-hook.php(324): EnableMediaReplace\EnableMediaReplacePlugin->runtime('')
#19 /wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#20 /wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#21 /wp-settings.php(578): do_action('plugins_loaded')
#22 /wp-config.php(76): require_once('...')
#23 /wp-load.php(50): require_once('...')
#24 /wp-blog-header.php(13): require_once('...')
#25 /index.php(17): require('...')
```

Code path
1. `determine_current_user` gets invoked
2. jwt-auth validates token and generates message for response with gettext string translation
3. string translation checks user locale
4. `get_user_locale()` invokes `determine_current_user`

Details
- Balancing string translations with user authentication in this early stage of a request is hard.
- It is possible that there are further possible code paths for infinite recursions in similar cross-dependencies (even before #139).
- Removing string translations from the response would resolve the problem in all cases.
- But unless we find other cases, we can just shield the string translations.

Proposed solution
1. Only invoke gettext string translation if the gettext domain has been loaded already.
